### PR TITLE
Handling of null bolus

### DIFF
--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -1337,8 +1337,9 @@ extension MainViewController {
             dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
             let dateString = dateFormatter.date(from: strippedZone)
             let dateTimeStamp = dateString!.timeIntervalSince1970
-            do {
-                let bolus = try currentEntry?["insulin"] as! Double
+            if !(currentEntry?["insulin"] is NSNull)
+            {
+                let bolus = currentEntry?["insulin"] as! Double
                 let sgv = findNearestBGbyTime(needle: dateTimeStamp, haystack: bgData, startingIndex: lastFoundIndex)
                 lastFoundIndex = sgv.foundIndex
                 
@@ -1347,8 +1348,9 @@ extension MainViewController {
                     let dot = bolusGraphStruct(value: bolus, date: Double(dateTimeStamp), sgv: Int(sgv.sgv + 20))
                     bolusData.append(dot)
                 }
-            } catch {
-                if UserDefaultsRepository.debugLog.value { self.writeDebugLog(value: "ERROR: Null Bolus") }
+            }
+            else if UserDefaultsRepository.debugLog.value {
+                self.writeDebugLog(value: "ERROR: Null Bolus")
             }
             
            


### PR DESCRIPTION
If a bolus is cancelled it generates a bolus with a null value.

Current implementation in dev gives this error:
![image](https://user-images.githubusercontent.com/12718238/96377460-25a82b00-1186-11eb-830d-01b5ba5e97f0.png)

In this pull request I have a suggestion that works fine for me with a null-bolus.