### PR TITLE
setting to use useIFCC A1C

### DIFF
--- a/LoopFollow/Controllers/AppStateController.swift
+++ b/LoopFollow/Controllers/AppStateController.swift
@@ -44,6 +44,7 @@ enum GeneralSettingsChangeEnum: Int {
    case screenlockSwitchStateChange = 512
     case showStatsChange = 1024
     case showSmallGraphChange = 2048
+    case useIFCCChange = 4096
 }
 
 class AppStateController {

--- a/LoopFollow/Controllers/Stats.swift
+++ b/LoopFollow/Controllers/Stats.swift
@@ -64,16 +64,16 @@ class StatsData {
         for i in 0..<bgData.count {
             partialSum += (Float(bgData[i].sgv) - avgBG) * ( Float(bgData[i].sgv) - avgBG)
         }
-        stdDev = sqrt(partialSum / Float(bgData.count))
         
-        if UserDefaultsRepository.units.value == "mg/dL" {
-            a1C = (46.7 + Float(avgBG)) / 28.7
+        stdDev = sqrt(partialSum / Float(bgData.count))
+        if UserDefaultsRepository.units.value != "mg/dL" {
+            stdDev = Float( bgUnits.toDisplayUnits( String( stdDev ) ) ) ?? 0.0;
+        }
+        
+        if UserDefaultsRepository.useIFCC.value {
+            a1C = (((46.7 + Float(avgBG)) / 28.7) - 2.152) / 0.09148
         } else {
             a1C = (46.7 + Float(avgBG)) / 28.7
-            // Keep this for later.
-            // https://github.com/nightscout/nightguard/pull/72
-            // a1C = (((46.7 + Float(avgBG)) / 28.7) - 2.152) / 0.09148
-            stdDev = Float( bgUnits.toDisplayUnits( String( stdDev ) ) ) ?? 0.0;
         }
          
     }

--- a/LoopFollow/Controllers/StatsView.swift
+++ b/LoopFollow/Controllers/StatsView.swift
@@ -22,7 +22,13 @@ extension MainViewController {
             statsInRangePercent.text = String(format:"%.1f%", stats.percentRange) + "%"
             statsHighPercent.text = String(format:"%.1f%", stats.percentHigh) + "%"
             statsAvgBG.text = bgUnits.toDisplayUnits(String(format:"%.0f%", stats.avgBG))
-            statsEstA1C.text = String(format:"%.1f%", stats.a1C)
+            if UserDefaultsRepository.useIFCC.value {
+                statsEstA1C.text = String(format:"%.0f%", stats.a1C)
+            }
+            else
+            {
+                statsEstA1C.text = String(format:"%.1f%", stats.a1C)
+            }
             statsStdDev.text = String(format:"%.2f%", stats.stdDev)
             
             createStatsPie(pieData: stats.pie)

--- a/LoopFollow/ViewControllers/GeneralSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/GeneralSettingsViewController.swift
@@ -83,6 +83,19 @@ class GeneralSettingsViewController: FormViewController {
                 appState.generalSettingsChanges |= GeneralSettingsChangeEnum.showStatsChange.rawValue
              }
         }
+        <<< SwitchRow("useIFCC") { row in
+        row.title = "Use IFCC A1C"
+        row.value = UserDefaultsRepository.useIFCC.value
+        }.onChange { [weak self] row in
+            guard let value = row.value else { return }
+            UserDefaultsRepository.useIFCC.value = value
+            
+             // set the appstate to indicate settings change and flags
+             if let appState = self!.appStateController {
+                appState.generalSettingsChanged = true
+                appState.generalSettingsChanges |= GeneralSettingsChangeEnum.useIFCCChange.rawValue
+             }
+        }
         <<< SwitchRow("showSmallGraph") { row in
         row.title = "Display Small Graph"
         row.value = UserDefaultsRepository.showSmallGraph.value

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -267,7 +267,12 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showStatsChange.rawValue != 0 {
                statsView.isHidden = !UserDefaultsRepository.showStats.value
             }
-            
+
+            // settings for useIFCC changed
+            if appState.generalSettingsChanges & GeneralSettingsChangeEnum.useIFCCChange.rawValue != 0 {
+                updateStats()
+            }
+
             // settings for showSmallGraph changed
             if appState.generalSettingsChanges & GeneralSettingsChangeEnum.showSmallGraphChange.rawValue != 0 {
                 BGChartFull.isHidden = !UserDefaultsRepository.showSmallGraph.value

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -57,6 +57,7 @@ class UserDefaultsRepository {
     // General Settings
     static let colorBGText = UserDefaultsValue<Bool>(key: "colorBGText", default: true)
     static let showStats = UserDefaultsValue<Bool>(key: "showStats", default: true)
+    static let useIFCC = UserDefaultsValue<Bool>(key: "useIFCC", default: false)
     static let showSmallGraph = UserDefaultsValue<Bool>(key: "showSmallGraph", default: true)
     static let speakBG = UserDefaultsValue<Bool>(key: "speakBG", default: false)
     static let backgroundRefreshFrequency = UserDefaultsValue<Double>(key: "backgroundRefreshFrequency", default: 1)


### PR DESCRIPTION
New setting for IFCC A1C
![image](https://user-images.githubusercontent.com/12718238/97748787-537a6180-1aee-11eb-91c8-87c7e3e2ea6d.png)

Default false

Toggling updates the stats view.

IFCC A1C can be used regardless of unit (mg/dl - mmol/L)