### PR TITLE
Added Repeat Alerts to Quiet Hours

### DIFF
--- a/AlarmViewController.swift
+++ b/AlarmViewController.swift
@@ -1,0 +1,2230 @@
+//
+//  AlarmViewController.swift
+//  LoopFollow
+//
+//  Created by Jon Fawcett on 6/3/20.
+//  Copyright © 2020 Jon Fawcett. All rights reserved.
+//
+
+
+import UIKit
+import Eureka
+
+class AlarmViewController: FormViewController {
+    var appStateController: AppStateController?
+    
+    var soundFiles: [String] = [
+        "Alarm_Buzzer",
+        "Alarm_Clock",
+        "Alert_Tone_Busy",
+        "Alert_Tone_Ringtone_1",
+        "Alert_Tone_Ringtone_2",
+        "Alien_Siren",
+        "Ambulance",
+        "Analog_Watch_Alarm",
+        "Big_Clock_Ticking",
+        "Burglar_Alarm_Siren_1",
+        "Burglar_Alarm_Siren_2",
+        "Cartoon_Ascend_Climb_Sneaky",
+        "Cartoon_Ascend_Then_Descend",
+        "Cartoon_Bounce_To_Ceiling",
+        "Cartoon_Dreamy_Glissando_Harp",
+        "Cartoon_Fail_Strings_Trumpet",
+        "Cartoon_Machine_Clumsy_Loop",
+        "Cartoon_Siren",
+        "Cartoon_Tip_Toe_Sneaky_Walk",
+        "Cartoon_Uh_Oh",
+        "Cartoon_Villain_Horns",
+        "Cell_Phone_Ring_Tone",
+        "Chimes_Glassy",
+        "Computer_Magic",
+        "CSFX-2_Alarm",
+        "Cuckoo_Clock",
+        "Dhol_Shuffleloop",
+        "Discreet",
+        "Early_Sunrise",
+        "Emergency_Alarm_Carbon_Monoxide",
+        "Emergency_Alarm_Siren",
+        "Emergency_Alarm",
+        "Ending_Reached",
+        "Fly",
+        "Ghost_Hover",
+        "Good_Morning",
+        "Hell_Yeah_Somewhat_Calmer",
+        "In_A_Hurry",
+        "Indeed",
+        "Insistently",
+        "Jingle_All_The_Way",
+        "Laser_Shoot",
+        "Machine_Charge",
+        "Magical_Twinkle",
+        "Marching_Heavy_Footed_Fat_Elephants",
+        "Marimba_Descend",
+        "Marimba_Flutter_or_Shake",
+        "Martian_Gun",
+        "Martian_Scanner",
+        "Metallic",
+        "Nightguard",
+        "Not_Kiddin",
+        "Open_Your_Eyes_And_See",
+        "Orchestral_Horns",
+        "Oringz",
+        "Pager_Beeps",
+        "Remembers_Me_Of_Asia",
+        "Rise_And_Shine",
+        "Rush",
+        "Sci-Fi_Air_Raid_Alarm",
+        "Sci-Fi_Alarm_Loop_1",
+        "Sci-Fi_Alarm_Loop_2",
+        "Sci-Fi_Alarm_Loop_3",
+        "Sci-Fi_Alarm_Loop_4",
+        "Sci-Fi_Alarm",
+        "Sci-Fi_Computer_Console_Alarm",
+        "Sci-Fi_Console_Alarm",
+        "Sci-Fi_Eerie_Alarm",
+        "Sci-Fi_Engine_Shut_Down",
+        "Sci-Fi_Incoming_Message_Alert",
+        "Sci-Fi_Spaceship_Message",
+        "Sci-Fi_Spaceship_Warm_Up",
+        "Sci-Fi_Warning",
+        "Signature_Corporate",
+        "Siri_Alert_Calibration_Needed",
+        "Siri_Alert_Device_Muted",
+        "Siri_Alert_Glucose_Dropping_Fast",
+        "Siri_Alert_Glucose_Rising_Fast",
+        "Siri_Alert_High_Glucose",
+        "Siri_Alert_Low_Glucose",
+        "Siri_Alert_Missed_Readings",
+        "Siri_Alert_Transmitter_Battery_Low",
+        "Siri_Alert_Urgent_High_Glucose",
+        "Siri_Alert_Urgent_Low_Glucose",
+        "Siri_Calibration_Needed",
+        "Siri_Device_Muted",
+        "Siri_Glucose_Dropping_Fast",
+        "Siri_Glucose_Rising_Fast",
+        "Siri_High_Glucose",
+        "Siri_Low_Glucose",
+        "Siri_Missed_Readings",
+        "Siri_Transmitter_Battery_Low",
+        "Siri_Urgent_High_Glucose",
+        "Siri_Urgent_Low_Glucose",
+        "Soft_Marimba_Pad_Positive",
+        "Soft_Warm_Airy_Optimistic",
+        "Soft_Warm_Airy_Reassuring",
+        "Store_Door_Chime",
+        "Sunny",
+        "Thunder_Sound_FX",
+        "Time_Has_Come",
+        "Tornado_Siren",
+        "Two_Turtle_Doves",
+        "Unpaved",
+        "Wake_Up_Will_You",
+        "Win_Gain",
+        "Wrong_Answer"
+    ]
+    
+    var alertRepeatOptions: [String] = [
+        "Do not repeat",
+        "Always repeat",
+        "Repeat at night",
+        "Repeat during the day"
+    ]
+    
+    func timeBasedSettings (pickerValue: String) -> (dayTime:Bool, nightTime:Bool) {
+        var dayTime = false
+        var nightTime = false
+        
+        if pickerValue.contains("Always") {
+            dayTime = true
+            nightTime = true
+        }else{
+            if pickerValue.contains("night"){
+                nightTime = true
+            }
+            if pickerValue.contains("day"){
+                dayTime = true
+            }
+        }
+        return (dayTime, nightTime)
+    }
+    
+    func reloadSnoozeTime(key: String, setNil: Bool, value: Date = Date()) {
+        
+            if let row = form.rowBy(tag: key) as? DateTimeInlineRow {
+                if setNil {
+                    row.value = nil
+                } else {
+                   row.value = value
+                }
+                
+                row.reload()
+            }
+               
+    }
+    
+    func reloadIsSnoozed(key: String, value: Bool) {
+        
+            if let row = form.rowBy(tag: key) as? SwitchRow {
+            row.value = value
+            row.reload()
+            }
+    }
+    
+    
+    
+   // static let shared = AlarmViewController()
+
+    @IBAction func unwindToAlarms(sender: UIStoryboardSegue)
+     {
+     }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if UserDefaultsRepository.forceDarkMode.value {
+            overrideUserInterfaceStyle = .dark
+        }
+        
+        
+        form
+            +++ Section("Select Alert")
+          <<< SegmentedRow<String>("bgAlerts"){ row in
+                row.title = ""
+                row.options = ["Urgent Low", "Low", "High", "Urgent High"]
+                   // row.value = "Urgent Low"
+        }.onChange { [weak self] row in
+            guard let value = row.value else { return }
+            let otherRow = self?.form.rowBy(tag: "bgExtraAlerts") as! SegmentedRow<String>
+            otherRow.value = nil
+            otherRow.reload()
+            let otherRow2 = self?.form.rowBy(tag: "otherAlerts") as! SegmentedRow<String>
+            otherRow2.value = nil
+            otherRow2.reload()
+            let otherRow3 = self?.form.rowBy(tag: "otherAlerts2") as! SegmentedRow<String>
+            otherRow3.value = nil
+            otherRow3.reload()
+            row.value = value
+        }
+            <<< SegmentedRow<String>("bgExtraAlerts"){ row in
+                row.title = ""
+                row.options = ["No Readings", "Fast Drop", "Fast Rise", "Temporary"]
+                    //row.value = "Missed Readings"
+        }.onChange { [weak self] row in
+             guard let value = row.value else { return }
+            let otherRow = self?.form.rowBy(tag: "bgAlerts") as! SegmentedRow<String>
+               otherRow.value = nil
+               otherRow.reload()
+               let otherRow2 = self?.form.rowBy(tag: "otherAlerts") as! SegmentedRow<String>
+               otherRow2.value = nil
+               otherRow2.reload()
+            let otherRow3 = self?.form.rowBy(tag: "otherAlerts2") as! SegmentedRow<String>
+            otherRow3.value = nil
+            otherRow3.reload()
+            row.value = value
+        }
+            <<< SegmentedRow<String>("otherAlerts"){ row in
+                row.title = ""
+                row.options = ["Not Looping", "Missed Bolus", "SAGE", "CAGE"]
+                if UserDefaultsRepository.url.value == "" {
+                    row.hidden = true
+                }
+                
+                //row.value = "Not Looping"
+        }.onChange { [weak self] row in
+             guard let value = row.value else { return }
+            let otherRow = self?.form.rowBy(tag: "bgExtraAlerts") as! SegmentedRow<String>
+           otherRow.value = nil
+           otherRow.reload()
+           let otherRow2 = self?.form.rowBy(tag: "bgAlerts") as! SegmentedRow<String>
+           otherRow2.value = nil
+           otherRow2.reload()
+            let otherRow3 = self?.form.rowBy(tag: "otherAlerts2") as! SegmentedRow<String>
+            otherRow3.value = nil
+            otherRow3.reload()
+            row.value = value
+        }
+        <<< SegmentedRow<String>("otherAlerts2"){ row in
+                row.title = ""
+                row.options = ["Override Start", "Override End", "Pump"]
+                if UserDefaultsRepository.url.value == "" {
+                    row.hidden = true
+                }
+                //row.value = "Not Looping"
+        }.onChange { [weak self] row in
+             guard let value = row.value else { return }
+            let otherRow = self?.form.rowBy(tag: "bgExtraAlerts") as! SegmentedRow<String>
+           otherRow.value = nil
+           otherRow.reload()
+           let otherRow2 = self?.form.rowBy(tag: "bgAlerts") as! SegmentedRow<String>
+           otherRow2.value = nil
+           otherRow2.reload()
+            let otherRow3 = self?.form.rowBy(tag: "otherAlerts") as! SegmentedRow<String>
+            otherRow3.value = nil
+            otherRow3.reload()
+            row.value = value
+        }
+        
+
+        
+        buildUrgentLow()
+        buildLow()
+        buildHigh()
+        buildUrgentHigh()
+        
+        
+        
+        buildFastDropAlert()
+        buildFastRiseAlert()
+        buildMissedReadings()
+        
+        
+        
+        buildNotLooping()
+        buildMissedBolus()
+        buildSage()
+        buildCage()
+        
+        buildTemporaryAlert()
+        
+        buildOverrideStart()
+        buildOverrideEnd()
+        buildPump()
+        
+        buildSnoozeAll()
+        buildAppInactive()
+        buildAlarmSettings()
+        
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        showHideNSDetails()
+    }
+    
+    func showHideNSDetails() {
+        var isHidden = false
+        var isEnabled = true
+        if UserDefaultsRepository.url.value == "" {
+            isHidden = true
+            isEnabled = false
+        }
+        
+        if let row1 = form.rowBy(tag: "otherAlerts") as? SegmentedRow<String> {
+            row1.hidden = .function(["hide"],  {form in
+                return isHidden
+            })
+            row1.evaluateHidden()
+        }
+        if let row2 = form.rowBy(tag: "overrideAlerts") as? SegmentedRow<String> {
+            row2.hidden = .function(["hide"],  {form in
+                return isHidden
+            })
+            row2.evaluateHidden()
+        }
+        if let row3 = form.sectionBy(tag: "quietHourSection") as? Section {
+            row3.hidden = .function(["hide"],  {form in
+                return isHidden
+            })
+            row3.evaluateHidden()
+        }
+        
+        guard let nightscoutTab = self.tabBarController?.tabBar.items![3] else { return }
+        nightscoutTab.isEnabled = isEnabled
+        
+    }
+
+    func buildSnoozeAll(){
+        form
+            +++ Section(header: "Snooze All", footer: "Snooze All Alerts")
+        <<< DateTimeInlineRow("alertSnoozeAllTime") { row in
+            row.title = "Snooze All Until"
+            
+            if (UserDefaultsRepository.alertSnoozeAllTime.value != nil) {
+                row.value = UserDefaultsRepository.alertSnoozeAllTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertSnoozeAllTime.value = value
+                UserDefaultsRepository.alertSnoozeAllIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertSnoozeAllIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+            
+        <<< SwitchRow("alertSnoozeAllIsSnoozed"){ row in
+            row.title = "All Alerts Snoozed"
+            row.value = UserDefaultsRepository.alertSnoozeAllIsSnoozed.value
+            row.hidden = "$alertSnoozeAllTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertSnoozeAllIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertSnoozeAllTime.setNil(key: "alertSnoozeAllTime")
+                    let otherRow = self?.form.rowBy(tag: "alertSnoozeAllTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildTemporaryAlert(){
+        form
+            
+            
+            +++ Section(header: "Temporary Alert", footer: "Temporary Alert will trigger once and disable. Disabling Alert Below BG will trigger it as a high alert above the BG.") { row in
+                row.hidden = "$bgExtraAlerts != 'Temporary'"
+            }
+            <<< SwitchRow("alertTemporaryActive"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertTemporaryActive.value
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertTemporaryActive.value = value
+            }
+            <<< SwitchRow("alertTemporaryBelow"){ row in
+                row.title = "Alert Below BG"
+                row.value = UserDefaultsRepository.alertTemporaryBelow.value
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertTemporaryBelow.value = value
+            }
+            <<< StepperRow("alertTemporaryBG") { row in
+                row.title = "BG"
+                row.cell.stepper.stepValue = 1
+                row.cell.stepper.minimumValue = 40
+                row.cell.stepper.maximumValue = 400
+                row.value = Double(UserDefaultsRepository.alertTemporaryBG.value)
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return bgUnits.toDisplayUnits(String(value))
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertTemporaryBG.value = Float(value)
+            }
+            <<< PickerInputRow<String>("alertTemporarySound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertTemporarySound.value
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertTemporarySound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+        }
+        <<< SwitchRow("alertTemporaryRepeat"){ row in
+        row.title = "Repeat Alert"
+        row.value = UserDefaultsRepository.alertTemporaryBGRepeat.value
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertTemporaryBGRepeat.value = value
+        }
+    }
+    
+    func buildUrgentLow(){
+        form
+            +++ Section(header: "Urgent Low Alert", footer: "Alerts when BG drops below value") { row in
+                           row.hidden = "$bgAlerts != 'Urgent Low'"
+                       }
+        <<< SwitchRow("alertUrgentLowActive"){ row in
+            row.title = "Active"
+            row.value = UserDefaultsRepository.alertUrgentLowActive.value
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertUrgentLowActive.value = value
+            }
+        <<< StepperRow("alertUrgentLowBG") { row in
+            row.title = "BG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 40
+            row.cell.stepper.maximumValue = 80
+            row.value = Double(UserDefaultsRepository.alertUrgentLowBG.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return bgUnits.toDisplayUnits(String(value))
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertUrgentLowBG.value = Float(value)
+        }
+        <<< StepperRow("alertUrgentLowSnooze") { row in
+            row.title = "Default Snooze"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 5
+            row.cell.stepper.maximumValue = 15
+            row.value = Double(UserDefaultsRepository.alertUrgentLowSnooze.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertUrgentLowSnooze.value = Int(value)
+        }
+            <<< PickerInputRow<String>("alertUrgentLowSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertUrgentLowSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertUrgentLowSound.value = value //changed
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertUrgentLowRepeat") { row in
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertUrgentLowRepeat.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertUrgentLowRepeat.value = value
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertUrgentLowDayTime.value = alertTimes.dayTime
+                    UserDefaultsRepository.alertUrgentLowNightTime.value = alertTimes.nightTime
+            }
+        <<< DateTimeInlineRow("alertUrgentLowSnoozedTime") { row in
+            row.title = "Snoozed Until"
+            
+            if (UserDefaultsRepository.alertUrgentLowSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertUrgentLowSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertUrgentLowSnoozedTime.value = value
+                UserDefaultsRepository.alertUrgentLowIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertUrgentLowIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+            
+        <<< SwitchRow("alertUrgentLowIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertUrgentLowIsSnoozed.value
+            row.hidden = "$alertUrgentLowSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertUrgentLowIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertUrgentLowSnoozedTime.setNil(key: "alertUrgentLowSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertUrgentLowSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildLow(){
+        form
+            +++ Section(header: "Low Alert", footer: "Alerts when BG drops below value") { row in
+                row.hidden = "$bgAlerts != 'Low'"
+            }
+        <<< SwitchRow("alertLowActive"){ row in
+            row.title = "Active"
+            row.value = UserDefaultsRepository.alertLowActive.value
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertLowActive.value = value
+            }
+        <<< StepperRow("alertLowBG") { row in
+            row.title = "BG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 40
+            row.cell.stepper.maximumValue = 150
+            row.value = Double(UserDefaultsRepository.alertLowBG.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return bgUnits.toDisplayUnits(String(value))
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertLowBG.value = Float(value)
+        }
+        <<< StepperRow("alertLowSnooze") { row in
+            row.title = "Snooze"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 5
+            row.cell.stepper.maximumValue = 30
+            row.value = Double(UserDefaultsRepository.alertLowSnooze.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertLowSnooze.value = Int(value)
+        }
+            <<< PickerInputRow<String>("alertLowSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertLowSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertLowSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertLowRepeat") { row in
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertLowRepeat.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertLowRepeat.value = value
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertLowDayTime.value = alertTimes.dayTime
+                    UserDefaultsRepository.alertLowNightTime.value = alertTimes.nightTime
+            }
+        <<< DateTimeInlineRow("alertLowSnoozedTime") { row in
+            row.title = "Snoozed Until"
+           if (UserDefaultsRepository.alertLowSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertLowSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertLowSnoozedTime.value = value
+                UserDefaultsRepository.alertLowIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertLowIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+        <<< SwitchRow("alertLowIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertLowIsSnoozed.value
+            row.hidden = "$alertLowSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertLowIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertLowSnoozedTime.setNil(key: "alertLowSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertLowSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildHigh(){
+        form
+        +++ Section(header: "High Alert", footer: "Alerts when BG rises above value. If Persistence is set greater than 0, it will not alert until BG has been high for that many minutes.") { row in
+                       row.hidden = "$bgAlerts != 'High'"
+                   }
+            
+        <<< SwitchRow("alertHighActive"){ row in
+            row.title = "Active"
+            row.value = UserDefaultsRepository.alertHighActive.value
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertHighActive.value = value
+            }
+        
+        <<< StepperRow("alertHighBG") { row in
+            row.title = "BG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 120
+            row.cell.stepper.maximumValue = 300
+            row.value = Double(UserDefaultsRepository.alertHighBG.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return bgUnits.toDisplayUnits(String(value))
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertHighBG.value = Float(value)
+        }
+        <<< StepperRow("alertHighPersistent") { row in
+            row.title = "Persistent For"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 0
+            row.cell.stepper.maximumValue = 120
+            row.value = Double(UserDefaultsRepository.alertHighPersistent.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return "\(Int(value))"
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertHighPersistent.value = Int(value)
+        }
+        <<< StepperRow("alertHighSnooze") { row in
+            row.title = "Snooze"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 10
+            row.cell.stepper.maximumValue = 120
+            row.value = Double(UserDefaultsRepository.alertHighSnooze.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertHighSnooze.value = Int(value)
+        }
+            <<< PickerInputRow<String>("alertHighSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertHighSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertHighSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertHighRepeat") { row in
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertHighRepeat.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertHighRepeat.value = value
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertHighDayTime.value = alertTimes.dayTime
+                    UserDefaultsRepository.alertHighNightTime.value = alertTimes.nightTime
+            }
+        <<< DateTimeInlineRow("alertHighSnoozedTime") { row in
+            row.title = "Snoozed Until"
+            if (UserDefaultsRepository.alertHighSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertHighSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertHighSnoozedTime.value = value
+                UserDefaultsRepository.alertHighIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertHighIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+        <<< SwitchRow("alertHighIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertHighIsSnoozed.value
+            row.hidden = "$alertHighSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertHighIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertHighSnoozedTime.setNil(key: "alertHighSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertHighSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildUrgentHigh(){
+        form
+            +++ Section(header: "Urgent High Alert", footer: "Alerts when BG rises above value.") { row in
+                           row.hidden = "$bgAlerts != 'Urgent High'"
+                       }
+        <<< SwitchRow("alertUrgentHighActive"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertUrgentHighActive.value
+                }.onChange { [weak self] row in
+                        guard let value = row.value else { return }
+                        UserDefaultsRepository.alertUrgentHighActive.value = value
+                }
+        <<< StepperRow("alertUrgentHighBG") { row in
+            row.title = "BG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 120
+            row.cell.stepper.maximumValue = 350
+            row.value = Double(UserDefaultsRepository.alertUrgentHighBG.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return bgUnits.toDisplayUnits(String(value))
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertUrgentHighBG.value = Float(value)
+        }
+        <<< StepperRow("alertUrgentHighSnooze") { row in
+            row.title = "Snooze"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 10
+            row.cell.stepper.maximumValue = 120
+            row.value = Double(UserDefaultsRepository.alertUrgentHighSnooze.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertUrgentHighSnooze.value = Int(value)
+        }
+            <<< PickerInputRow<String>("alertUrgentHighSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertUrgentHighSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertUrgentHighSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertUrgentHighRepeat") { row in
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertUrgentHighRepeat.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertUrgentHighRepeat.value = value
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertUrgentHighDayTime.value = alertTimes.dayTime
+                    UserDefaultsRepository.alertUrgentHighNightTime.value = alertTimes.nightTime
+            }
+        <<< DateTimeInlineRow("alertUrgentHighSnoozedTime") { row in
+            row.title = "Snoozed Until"
+            if (UserDefaultsRepository.alertUrgentHighSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertUrgentHighSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertUrgentHighSnoozedTime.value = value
+                UserDefaultsRepository.alertUrgentHighIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertUrgentHighIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+        <<< SwitchRow("alertUrgentHighIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertUrgentHighIsSnoozed.value
+            row.hidden = "$alertUrgentHighSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertUrgentHighIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertUrgentHighSnoozedTime.setNil(key: "alertUrgentHighSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertUrgentHighSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildFastDropAlert(){
+        form
+        +++ Section(header: "Fast Drop Alert", footer: "Alert when BG is dropping fast over consecutive readings. Optional: only alert when dropping below a specific BG") { row in
+                                  row.hidden = "$bgExtraAlerts != 'Fast Drop'"
+                              }
+        <<< SwitchRow("alertFastDropActive"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertFastDropActive.value
+                }.onChange { [weak self] row in
+                        guard let value = row.value else { return }
+                        UserDefaultsRepository.alertFastDropActive.value = value
+                }
+        <<< StepperRow("alertFastDropDelta") { row in
+            row.title = "Delta"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 3
+            row.cell.stepper.maximumValue = 20
+            row.value = Double(UserDefaultsRepository.alertFastDropDelta.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return bgUnits.toDisplayUnits(String(value))
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastDropDelta.value = Float(value)
+        }
+        <<< StepperRow("alertFastDropReadings") { row in
+            row.title = "# Readings"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 2
+            row.cell.stepper.maximumValue = 4
+            row.value = Double(UserDefaultsRepository.alertFastDropReadings.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return "\(Int(value))"
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastDropReadings.value = Int(value)
+        }
+        <<< SwitchRow("alertFastDropUseLimit"){ row in
+        row.title = "Use BG Limit"
+        row.value = UserDefaultsRepository.alertFastDropUseLimit.value
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastDropUseLimit.value = value
+        }
+    
+        <<< StepperRow("alertFastDropBelowBG") { row in
+            row.title = "Dropping Below BG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 40
+            row.cell.stepper.maximumValue = 300
+            row.value = Double(UserDefaultsRepository.alertFastDropBelowBG.value)
+            row.hidden = "$alertFastDropUseLimit == false"
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return bgUnits.toDisplayUnits(String(value))
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastDropBelowBG.value = Float(value)
+        }
+        <<< StepperRow("alertFastDropSnooze") { row in
+            row.title = "Snooze"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 5
+            row.cell.stepper.maximumValue = 60
+            row.value = Double(UserDefaultsRepository.alertFastDropSnooze.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastDropSnooze.value = Int(value)
+        }
+            <<< PickerInputRow<String>("alertFastDropSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertFastDropSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertFastDropSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertFastDropRepeat") { row in
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertFastDropRepeat.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertFastDropRepeat.value = value
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertFastDropDayTime.value = alertTimes.dayTime
+                    UserDefaultsRepository.alertFastDropNightTime.value = alertTimes.nightTime
+            }
+        <<< DateTimeInlineRow("alertFastDropSnoozedTime") { row in
+            row.title = "Snoozed Until"
+           if (UserDefaultsRepository.alertFastDropSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertFastDropSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastDropSnoozedTime.value = value
+                UserDefaultsRepository.alertFastDropIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertFastDropIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+        <<< SwitchRow("alertFastDropIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertFastDropIsSnoozed.value
+            row.hidden = "$alertFastDropSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastDropIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertFastDropSnoozedTime.setNil(key: "alertFastDropSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertFastDropSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildFastRiseAlert(){
+        form
+        +++ Section(header: "Fast Rise Alert", footer: "Alert when BG is rising fast over consecutive readings. Optional: only alert when rising above a specific BG") { row in
+                                         row.hidden = "$bgExtraAlerts != 'Fast Rise'"
+                                     }
+        <<< SwitchRow("alertFastRiseActive"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertFastRiseActive.value
+                }.onChange { [weak self] row in
+                        guard let value = row.value else { return }
+                        UserDefaultsRepository.alertFastRiseActive.value = value
+                }
+        <<< StepperRow("alertFastRiseDelta") { row in
+            row.title = "Delta"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 3
+            row.cell.stepper.maximumValue = 20
+            row.value = Double(UserDefaultsRepository.alertFastRiseDelta.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return bgUnits.toDisplayUnits(String(value))
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastRiseDelta.value = Float(value)
+        }
+        <<< StepperRow("alertFastRiseReadings") { row in
+            row.title = "# Readings"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 2
+            row.cell.stepper.maximumValue = 4
+            row.value = Double(UserDefaultsRepository.alertFastRiseReadings.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return "\(Int(value))"
+            }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastRiseReadings.value = Int(value)
+        }
+        <<< SwitchRow("alertFastRiseUseLimit"){ row in
+        row.title = "Use BG Limit"
+        row.value = UserDefaultsRepository.alertFastRiseUseLimit.value
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastRiseUseLimit.value = value
+        }
+    
+        <<< StepperRow("alertFastRiseAboveBG") { row in
+            row.title = "Rising Above BG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 40
+            row.cell.stepper.maximumValue = 300
+            row.value = Double(UserDefaultsRepository.alertFastRiseAboveBG.value)
+            row.hidden = "$alertFastRiseUseLimit == false"
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return bgUnits.toDisplayUnits(String(value))
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastRiseAboveBG.value = Float(value)
+        }
+        <<< StepperRow("alertFastRiseSnooze") { row in
+            row.title = "Snooze"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 5
+            row.cell.stepper.maximumValue = 60
+            row.value = Double(UserDefaultsRepository.alertFastRiseSnooze.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastRiseSnooze.value = Int(value)
+        }
+            <<< PickerInputRow<String>("alertFastRiseSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertFastRiseSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertFastRiseSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertFastRiseRepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertFastRiseRepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertFastRiseRepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertFastRiseDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertFastRiseNightTime.value = alertTimes.nightTime // <--
+            }
+        <<< DateTimeInlineRow("alertFastRiseSnoozedTime") { row in
+            row.title = "Snoozed Until"
+           if (UserDefaultsRepository.alertFastRiseSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertFastRiseSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastRiseSnoozedTime.value = value
+                UserDefaultsRepository.alertFastRiseIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertFastRiseIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+        <<< SwitchRow("alertFastRiseIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertFastRiseIsSnoozed.value
+            row.hidden = "$alertFastRiseSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertFastRiseIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertFastRiseSnoozedTime.setNil(key: "alertFastRiseSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertFastRiseSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildMissedReadings(){
+        form
+            +++ Section(header: "No Readings", footer: "Alert when there have been no BG readings for X minutes") { row in
+                                             row.hidden = "$bgExtraAlerts != 'No Readings'"
+                                         }
+        
+            <<< SwitchRow("alertMissedReadingActive"){ row in
+                    row.title = "Active"
+                    row.value = UserDefaultsRepository.alertMissedReadingActive.value
+                    }.onChange { [weak self] row in
+                            guard let value = row.value else { return }
+                            UserDefaultsRepository.alertMissedReadingActive.value = value
+                    }
+        
+            <<< StepperRow("alertMissedReading") { row in
+                row.title = "Time"
+                row.cell.stepper.stepValue = 5
+                row.cell.stepper.minimumValue = 10
+                row.cell.stepper.maximumValue = 120
+                row.value = Double(UserDefaultsRepository.alertMissedReading.value)
+                row.displayValueFor = { value in
+                        guard let value = value else { return nil }
+                        return "\(Int(value))"
+                    }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertMissedReading.value = Int(value)
+            }
+            <<< StepperRow("alertMissedReadingSnooze") { row in
+                row.title = "Snooze"
+                row.cell.stepper.stepValue = 5
+                row.cell.stepper.minimumValue = 10
+                row.cell.stepper.maximumValue = 180
+                row.value = Double(UserDefaultsRepository.alertMissedReadingSnooze.value)
+                row.displayValueFor = { value in
+                        guard let value = value else { return nil }
+                        return "\(Int(value))"
+                    }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertMissedReadingSnooze.value = Int(value)
+            }
+            <<< PickerInputRow<String>("alertMissedReadingSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertMissedReadingSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertMissedReadingSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertMissedReadingRepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertMissedReadingRepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertMissedReadingRepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertMissedReadingDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertMissedReadingNightTime.value = alertTimes.nightTime // <--
+            }
+        <<< DateTimeInlineRow("alertMissedReadingSnoozedTime") { row in
+            row.title = "Snoozed Until"
+           if (UserDefaultsRepository.alertMissedReadingSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertMissedReadingSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertMissedReadingSnoozedTime.value = value
+                UserDefaultsRepository.alertMissedReadingIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertMissedReadingIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+        <<< SwitchRow("alertMissedReadingIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertMissedReadingIsSnoozed.value
+            row.hidden = "$alertMissedReadingSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertMissedReadingIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertMissedReadingSnoozedTime.setNil(key: "alertMissedReadingSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertMissedReadingSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildNotLooping(){
+        form
+            +++ Section(header: "Not Looping", footer: "Alert when Loop has not completed a successful Loop for X minutes") { row in
+                    row.hidden = "$otherAlerts != 'Not Looping'"
+                }
+        <<< SwitchRow("alertNotLoopingActive"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertNotLoopingActive.value
+                }.onChange { [weak self] row in
+                        guard let value = row.value else { return }
+                        UserDefaultsRepository.alertNotLoopingActive.value = value
+                }
+        <<< StepperRow("alertNotLooping") { row in
+            row.title = "Time"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 10
+            row.cell.stepper.maximumValue = 60
+            row.value = Double(UserDefaultsRepository.alertNotLooping.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertNotLooping.value = Int(value)
+        }
+        
+        <<< SwitchRow("alertNotLoopingUseLimits"){ row in
+        row.title = "Use BG Limits"
+        row.value = UserDefaultsRepository.alertNotLoopingUseLimits.value
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertNotLoopingUseLimits.value = value
+        }
+        <<< StepperRow("alertNotLoopingLowerLimit") { row in
+            row.title = "Below BG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 50
+            row.cell.stepper.maximumValue = 200
+            row.value = Double(UserDefaultsRepository.alertNotLoopingLowerLimit.value)
+            row.hidden = "$alertNotLoopingUseLimits == false"
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return bgUnits.toDisplayUnits(String(value))
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertNotLoopingLowerLimit.value = Float(value)
+        }
+        <<< StepperRow("alertNotLoopingUpperLimit") { row in
+            row.title = "Above BG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 100
+            row.cell.stepper.maximumValue = 300
+            row.value = Double(UserDefaultsRepository.alertNotLoopingUpperLimit.value)
+            row.hidden = "$alertNotLoopingUseLimits == false"
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return bgUnits.toDisplayUnits(String(value))
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertNotLoopingUpperLimit.value = Float(value)
+        }
+        <<< StepperRow("alertNotLoopingSnooze") { row in
+            row.title = "Snooze"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 10
+            row.cell.stepper.maximumValue = 120
+            row.value = Double(UserDefaultsRepository.alertNotLoopingSnooze.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertNotLoopingSnooze.value = Int(value)
+        }
+            <<< PickerInputRow<String>("alertNotLoopingSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertNotLoopingSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertNotLoopingSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertNotLoopingRepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertNotLoopingRepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertNotLoopingRepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertNotLoopingDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertNotLoopingNightTime.value = alertTimes.nightTime // <--
+            }
+        <<< DateTimeInlineRow("alertNotLoopingSnoozedTime") { row in
+            row.title = "Snoozed Until"
+           if (UserDefaultsRepository.alertNotLoopingSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertNotLoopingSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertNotLoopingSnoozedTime.value = value
+                UserDefaultsRepository.alertNotLoopingIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertNotLoopingIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+        <<< SwitchRow("alertNotLoopingIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertNotLoopingIsSnoozed.value
+            row.hidden = "$alertNotLoopingSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertNotLoopingIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertNotLoopingSnoozedTime.setNil(key: "alertNotLoopingSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertNotLoopingSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildMissedBolus(){
+        form
+            +++ Section(header: "Missed Bolus", footer: "Alert after X minutes when carbs are entered with no Bolus. Options to Ignore low treatment carbs under a certain BG, ignore small boluses, and consider boluses within a certain amount of time before the carbs as a prebolus.") { row in
+                               row.hidden = "$otherAlerts != 'Missed Bolus'"
+                           }
+        <<< SwitchRow("alertMissedBolusActive"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertMissedBolusActive.value
+                }.onChange { [weak self] row in
+                        guard let value = row.value else { return }
+                        UserDefaultsRepository.alertMissedBolusActive.value = value
+                }
+        <<< StepperRow("alertMissedBolus") { row in
+            row.title = "Time"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 5
+            row.cell.stepper.maximumValue = 60
+            row.value = Double(UserDefaultsRepository.alertMissedBolus.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertMissedBolus.value = Int(value)
+        }
+            <<< StepperRow("alertMissedBolusPrebolus") { row in
+                row.title = "Prebolus Max Time"
+                row.cell.stepper.stepValue = 5
+                row.cell.stepper.minimumValue = 1
+                row.cell.stepper.maximumValue = 45
+                row.value = Double(UserDefaultsRepository.alertMissedBolusPrebolus.value)
+                row.displayValueFor = { value in
+                        guard let value = value else { return nil }
+                        return "\(Int(value))"
+                    }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertMissedBolusPrebolus.value = Int(value)
+            }
+            <<< StepperRow("alertMissedBolusIgnoreBolus") { row in
+                row.title = "Ignore Bolus <="
+                row.cell.stepper.stepValue = 0.05
+                row.cell.stepper.minimumValue = 0.05
+                row.cell.stepper.maximumValue = 2
+                row.value = Double(UserDefaultsRepository.alertMissedBolusIgnoreBolus.value)
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertMissedBolusIgnoreBolus.value = value
+            }
+    
+        
+        <<< StepperRow("alertMissedBolusLowGrams") { row in
+            row.title = "Ignore Under Grams"
+            row.tag = "missedBolusLowGrams"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 0
+            row.cell.stepper.maximumValue = 15
+            row.value = Double(UserDefaultsRepository.alertMissedBolusLowGrams.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertMissedBolusLowGrams.value = Int(value)
+        }
+        <<< StepperRow("alertMissedBolusLowGramsBG") { row in
+            row.title = "Ignore Under BG"
+            row.tag = "missedBolusLowGramsBG"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 40
+            row.cell.stepper.maximumValue = 100
+            row.value = Double(UserDefaultsRepository.alertMissedBolusLowGramsBG.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return bgUnits.toDisplayUnits(String(value))
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertMissedBolusLowGramsBG.value = Float(value)
+        }
+        
+        <<< StepperRow("alertMissedBolusSnooze") { row in
+            row.title = "Snooze"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 5
+            row.cell.stepper.maximumValue = 60
+            row.value = Double(UserDefaultsRepository.alertMissedBolusSnooze.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertMissedBolusSnooze.value = Int(value)
+        }
+            <<< PickerInputRow<String>("alertMissedBolusSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertMissedBolusSound.value
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertMissedBolusSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertMissedBolusRepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertMissedBolusRepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertMissedBolusRepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertMissedBolusDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertMissedBolusNightTime.value = alertTimes.nightTime // <--
+            }
+        <<< DateTimeInlineRow("alertMissedBolusSnoozedTime") { row in
+            row.title = "Snoozed Until"
+           if (UserDefaultsRepository.alertMissedBolusSnoozedTime.value != nil) {
+                row.value = UserDefaultsRepository.alertMissedBolusSnoozedTime.value
+            }
+            row.minuteInterval = 5
+            row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertMissedBolusSnoozedTime.value = value
+                UserDefaultsRepository.alertMissedBolusIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertMissedBolusIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+        }
+        <<< SwitchRow("alertMissedBolusIsSnoozed"){ row in
+            row.title = "Is Snoozed"
+            row.value = UserDefaultsRepository.alertMissedBolusIsSnoozed.value
+            row.hidden = "$alertMissedBolusSnoozedTime == nil"
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertMissedBolusIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertMissedBolusSnoozedTime.setNil(key: "alertMissedBolusSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertMissedBolusSnoozedTime") as! DateTimeInlineRow
+                   otherRow.value = nil
+                   otherRow.reload()
+                }
+        }
+    }
+    
+    func buildAppInactive(){
+         form
+            +++ Section(header: "App Inactive", footer: "Attempt to alert if IOS kills the app in the background")
+        <<< SwitchRow("alertAppInactive"){ row in
+        row.title = "Active"
+        row.value = UserDefaultsRepository.alertAppInactive.value
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertAppInactive.value = value
+        }
+    }
+    
+    func buildSage(){
+        form
+            +++ Section(header: "Sensor Change Reminder", footer: "Alert for 10 Day Sensor Change. Values are in Hours.") { row in
+                row.hidden = "$otherAlerts != 'SAGE'"
+            }
+            
+            <<< SwitchRow("alertSAGEActive"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertSAGEActive.value
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertSAGEActive.value = value
+            }
+            
+            <<< StepperRow("alertSAGE") { row in
+                row.title = "Time"
+                row.cell.stepper.stepValue = 1
+                row.cell.stepper.minimumValue = 1
+                row.cell.stepper.maximumValue = 24
+                row.value = Double(UserDefaultsRepository.alertSAGE.value)
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertSAGE.value = Int(value)
+            }
+            <<< StepperRow("alertSAGESnooze") { row in
+                row.title = "Snooze"
+                row.cell.stepper.stepValue = 1
+                row.cell.stepper.minimumValue = 1
+                row.cell.stepper.maximumValue = 24
+                row.value = Double(UserDefaultsRepository.alertSAGESnooze.value)
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertSAGESnooze.value = Int(value)
+            }
+            
+            <<< PickerInputRow<String>("alertSAGESound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertSAGESound.value
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertSAGESound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertSAGERepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertSAGERepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertSAGERepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertSAGEDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertSAGENightTime.value = alertTimes.nightTime // <--
+            }
+            <<< DateTimeInlineRow("alertSAGESnoozedTime") { row in
+                row.title = "Snoozed Until"
+                if (UserDefaultsRepository.alertSAGESnoozedTime.value != nil) {
+                    row.value = UserDefaultsRepository.alertSAGESnoozedTime.value
+                }
+                row.minuteInterval = 5
+                row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertSAGESnoozedTime.value = value
+                UserDefaultsRepository.alertSAGEIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertSAGEIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+            }
+            <<< SwitchRow("alertSAGEIsSnoozed"){ row in
+                row.title = "Is Snoozed"
+                row.value = UserDefaultsRepository.alertSAGEIsSnoozed.value
+                row.hidden = "$alertSAGESnoozedTime == nil"
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertSAGEIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertSAGESnoozedTime.setNil(key: "alertSAGESnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertSAGESnoozedTime") as! DateTimeInlineRow
+                    otherRow.value = nil
+                    otherRow.reload()
+                }
+        }
+    }
+    
+    func buildCage(){
+        form
+            +++ Section(header: "Pump/Canula Change Reminder", footer: "Alert for Canula Change. Values are in Hours.") { row in
+                row.hidden = "$otherAlerts != 'CAGE'"
+            }
+            <<< SwitchRow("alertCAGEActive"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertCAGEActive.value
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertCAGEActive.value = value
+            }
+            
+            <<< StepperRow("alertCAGE") { row in
+                row.title = "Time"
+                row.cell.stepper.stepValue = 1
+                row.cell.stepper.minimumValue = 1
+                row.cell.stepper.maximumValue = 24
+                row.value = Double(UserDefaultsRepository.alertCAGE.value)
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertCAGE.value = Int(value)
+            }
+            <<< StepperRow("alertCAGESnooze") { row in
+                row.title = "Snooze"
+                row.cell.stepper.stepValue = 1
+                row.cell.stepper.minimumValue = 1
+                row.cell.stepper.maximumValue = 24
+                row.value = Double(UserDefaultsRepository.alertCAGESnooze.value)
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertCAGESnooze.value = Int(value)
+            }
+            <<< PickerInputRow<String>("alertCAGESound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertCAGESound.value
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertCAGESound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+            }
+            <<< PickerInputRow<String>("alertCAGERepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertCAGERepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertCAGERepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertCAGEDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertCAGENightTime.value = alertTimes.nightTime // <--
+            }
+            <<< DateTimeInlineRow("alertCAGESnoozedTime") { row in
+                row.title = "Snoozed Until"
+                if (UserDefaultsRepository.alertCAGESnoozedTime.value != nil) {
+                    row.value = UserDefaultsRepository.alertCAGESnoozedTime.value
+                }
+                row.minuteInterval = 5
+                row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertCAGESnoozedTime.value = value
+                UserDefaultsRepository.alertCAGEIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertCAGEIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+            }
+            <<< SwitchRow("alertCAGEIsSnoozed"){ row in
+                row.title = "Is Snoozed"
+                row.value = UserDefaultsRepository.alertCAGEIsSnoozed.value
+                row.hidden = "$alertCAGESnoozedTime == nil"
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertCAGEIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertCAGESnoozedTime.setNil(key: "alertCAGESnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertCAGESnoozedTime") as! DateTimeInlineRow
+                    otherRow.value = nil
+                    otherRow.reload()
+                }
+        }
+    }
+    
+    func buildOverrideStart(){
+        form
+            +++ Section(header: "Override Started Alert", footer: "Alert will trigger without repeat once when override is activated. There is no need to snooze this alert") { row in
+                row.hidden = "$otherAlerts2 != 'Override Start'"
+            }
+            <<< SwitchRow("alertOverrideStart"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertOverrideStart.value
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertOverrideStart.value = value
+            }
+            
+            <<< PickerInputRow<String>("alertOverrideStartSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertOverrideStartSound.value
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertOverrideStartSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+        }
+            <<< PickerInputRow<String>("alertOverrideStartRepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertOverrideStartRepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertOverrideStartRepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertOverrideStartDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertOverrideStartNightTime.value = alertTimes.nightTime // <--
+
+            }
+        <<< DateTimeInlineRow("alertOverrideStartSnoozedTime") { row in
+                row.title = "Snoozed Until"
+                if (UserDefaultsRepository.alertOverrideStartSnoozedTime.value != nil) {
+                    row.value = UserDefaultsRepository.alertOverrideStartSnoozedTime.value
+                }
+                row.minuteInterval = 5
+                row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertOverrideStartSnoozedTime.value = value
+                UserDefaultsRepository.alertOverrideStartIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertOverrideStartIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+            }
+            <<< SwitchRow("alertOverrideStartIsSnoozed"){ row in
+                row.title = "Is Snoozed"
+                row.value = UserDefaultsRepository.alertOverrideStartIsSnoozed.value
+                row.hidden = "$alertOverrideStartSnoozedTime == nil"
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertOverrideStartIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertOverrideStartSnoozedTime.setNil(key: "alertOverrideStartSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertOverrideStartSnoozedTime") as! DateTimeInlineRow
+                    otherRow.value = nil
+                    otherRow.reload()
+                }
+        }
+        
+    }
+    
+    func buildOverrideEnd(){
+        form
+            +++ Section(header: "Override Ended Alert", footer: "Alert will trigger without repeat once when an override is turned off. There is no need to snooze this alert") { row in
+                row.hidden = "$otherAlerts2 != 'Override End'"
+            }
+            <<< SwitchRow("alertOverrideEnd"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertOverrideEnd.value
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertOverrideEnd.value = value
+            }
+            
+            <<< PickerInputRow<String>("alertOverrideEndSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertOverrideEndSound.value
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertOverrideEndSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+        }
+            <<< PickerInputRow<String>("alertOverrideEndRepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertOverrideEndRepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertOverrideEndRepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertOverrideEndDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertOverrideEndNightTime.value = alertTimes.nightTime // <--
+            }
+        <<< DateTimeInlineRow("alertOverrideEndSnoozedTime") { row in
+                row.title = "Snoozed Until"
+                if (UserDefaultsRepository.alertOverrideEndSnoozedTime.value != nil) {
+                    row.value = UserDefaultsRepository.alertOverrideEndSnoozedTime.value
+                }
+                row.minuteInterval = 5
+                row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertOverrideEndSnoozedTime.value = value
+                UserDefaultsRepository.alertOverrideEndIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertOverrideEndIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+            }
+            <<< SwitchRow("alertOverrideEndIsSnoozed"){ row in
+                row.title = "Is Snoozed"
+                row.value = UserDefaultsRepository.alertOverrideEndIsSnoozed.value
+                row.hidden = "$alertOverrideEndSnoozedTime == nil"
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertOverrideEndIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertOverrideEndSnoozedTime.setNil(key: "alertOverrideEndSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertOverrideEndSnoozedTime") as! DateTimeInlineRow
+                    otherRow.value = nil
+                    otherRow.reload()
+                }
+        }
+        
+    }
+    
+    func buildPump() {
+        form
+            +++ Section(header: "Pump", footer: "Alert will trigger when pump reservoir is below value") { row in
+                row.hidden = "$otherAlerts2 != 'Pump'"
+            }
+            <<< SwitchRow("alertPump"){ row in
+                row.title = "Active"
+                row.value = UserDefaultsRepository.alertPump.value
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertPump.value = value
+            }
+            
+            <<< StepperRow("alertPumpAt") { row in
+                row.title = "Units Remaining"
+                row.cell.stepper.stepValue = 1
+                row.cell.stepper.minimumValue = 1
+                row.cell.stepper.maximumValue = 49
+                row.value = Double(UserDefaultsRepository.alertPumpAt.value)
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertPumpAt.value = Int(value)
+            }
+            
+            <<< StepperRow("alertPumpSnoozeHours") { row in
+                row.title = "Snooze Hours"
+                row.cell.stepper.stepValue = 1
+                row.cell.stepper.minimumValue = 1
+                row.cell.stepper.maximumValue = 24
+                row.value = Double(UserDefaultsRepository.alertPumpSnoozeHours.value)
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertPumpSnoozeHours.value = Int(value)
+            }
+            <<< PickerInputRow<String>("alertPumpSound") { row in
+                row.title = "Sound"
+                row.options = soundFiles
+                row.value = UserDefaultsRepository.alertPumpSound.value
+                row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertPumpSound.value = value
+                AlarmSound.setSoundFile(str: value)
+                AlarmSound.stop()
+                AlarmSound.playTest()
+        }
+            <<< PickerInputRow<String>("alertPumpRepeat") { row in // <--
+                row.title = "Repeat Alert"
+                row.options = alertRepeatOptions
+                row.value = UserDefaultsRepository.alertPumpRepeat.value // <--
+                row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                    return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+                }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.alertPumpRepeat.value = value // <--
+                    let alertTimes = self!.timeBasedSettings(pickerValue: value)
+                    UserDefaultsRepository.alertPumpDayTime.value = alertTimes.dayTime // <--
+                    UserDefaultsRepository.alertPumpNightTime.value = alertTimes.nightTime // <--
+            }
+
+            <<< DateTimeInlineRow("alertPumpSnoozedTime") { row in
+                row.title = "Snoozed Until"
+                if (UserDefaultsRepository.alertPumpSnoozedTime.value != nil) {
+                    row.value = UserDefaultsRepository.alertPumpSnoozedTime.value
+                }
+                row.minuteInterval = 5
+                row.noValueDisplayText = "Not Snoozed"
+            }
+            .onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertPumpSnoozedTime.value = value
+                UserDefaultsRepository.alertPumpIsSnoozed.value = true
+                let otherRow = self?.form.rowBy(tag: "alertPumpIsSnoozed") as! SwitchRow
+                otherRow.value = true
+                otherRow.reload()
+            }
+            .onExpandInlineRow { [weak self] cell, row, inlineRow in
+                inlineRow.cellUpdate() { cell, row in
+                    cell.datePicker.datePickerMode = .dateAndTime
+                    cell.datePicker.preferredDatePickerStyle = .wheels
+                }
+                let color = cell.detailTextLabel?.textColor
+                row.onCollapseInlineRow { cell, _, _ in
+                    cell.detailTextLabel?.textColor = color
+                }
+                cell.detailTextLabel?.textColor = cell.tintColor
+            }
+            <<< SwitchRow("alertPumpIsSnoozed"){ row in
+                row.title = "Is Snoozed"
+                row.value = UserDefaultsRepository.alertPumpIsSnoozed.value
+                row.hidden = "$alertPumpSnoozedTime == nil"
+            }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertPumpIsSnoozed.value = value
+                if !value {
+                    UserDefaultsRepository.alertPumpSnoozedTime.setNil(key: "alertPumpSnoozedTime")
+                    let otherRow = self?.form.rowBy(tag: "alertPumpSnoozedTime") as! DateTimeInlineRow
+                    otherRow.value = nil
+                    otherRow.reload()
+                }
+        }
+    }
+
+    func buildAlarmSettings() {
+           form
+            +++ Section(header: "Alarm Sound Settings", footer: "")
+           
+            <<< SwitchRow("overrideSystemOutputVolume"){ row in
+                row.title = "Override System Volume"
+                row.value = UserDefaultsRepository.overrideSystemOutputVolume.value
+            }.onChange { [weak self] row in
+                        guard let value = row.value else { return }
+                        UserDefaultsRepository.overrideSystemOutputVolume.value = value
+                }
+            <<< StepperRow("forcedOutputVolume") { row in
+                  row.title = "Volume Level"
+                row.cell.stepper.stepValue = 0.05
+                  row.cell.stepper.minimumValue = 0
+                  row.cell.stepper.maximumValue = 1
+                  row.value = Double(UserDefaultsRepository.forcedOutputVolume.value)
+                  row.hidden = "$overrideSystemOutputVolume == false"
+                    row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value*100))%"
+                    }
+              }.onChange { [weak self] row in
+                      guard let value = row.value else { return }
+                      UserDefaultsRepository.forcedOutputVolume.value = Float(value)
+              }
+            
+             +++ Section(header: "Night Time Settings", footer: "Defining night time hours can be used to differ how alerts are managed during the day and at night.  For instance, automatically snooze, at night time, non-critical alerts that you do not wish to be awakened for such as a sensor change pre-alert.")  { row in
+                row.tag = "quietHourSection"
+                        }
+            <<< TimeInlineRow("quietHourStart") { row in
+                row.title = "Night Time Starts Today"
+                row.value = UserDefaultsRepository.quietHourStart.value
+                
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.quietHourStart.value = value
+        }
+        <<< TimeInlineRow("quietHourEnd") { row in
+                row.title = "Night Time Ends Tomorrow"
+                row.value = UserDefaultsRepository.quietHourEnd.value
+                
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.quietHourEnd.value = value
+        }
+       }
+
+}
+
+

--- a/Alarms.swift
+++ b/Alarms.swift
@@ -1,0 +1,714 @@
+//
+//  Alarms.swift
+//  LoopFollow
+//
+//  Created by Jon Fawcett on 6/16/20.
+//  Copyright © 2020 Jon Fawcett. All rights reserved.
+//
+//
+
+import Foundation
+import AVFoundation
+
+extension MainViewController {
+    
+    
+    func checkAlarms(bgs: [ShareGlucoseData]) {
+        if UserDefaultsRepository.debugLog.value { self.writeDebugLog(value: "Checking Alarms") }
+        // Don't check or fire alarms within 1 minute of prior alarm
+        if checkAlarmTimer.isValid {  return }
+        
+        let date = Date()
+        let now = date.timeIntervalSince1970
+        let currentBG = bgs[bgs.count - 1].sgv
+        let lastBG = bgs[bgs.count - 2].sgv
+        
+        var deltas: [Int] = []
+        if bgs.count > 3 {
+            deltas.append(bgs[bgs.count - 1].sgv - bgs[bgs.count - 2].sgv)
+            deltas.append(bgs[bgs.count - 2].sgv - bgs[bgs.count - 3].sgv)
+            deltas.append(bgs[bgs.count - 3].sgv - bgs[bgs.count - 4].sgv)
+        } else if bgs.count > 2 {
+            deltas.append(bgs[bgs.count - 1].sgv - bgs[bgs.count - 2].sgv)
+            deltas.append(bgs[bgs.count - 2].sgv - bgs[bgs.count - 3].sgv)
+            // Set remainder to match the last delta we have
+            deltas.append(bgs[bgs.count - 2].sgv - bgs[bgs.count - 3].sgv)
+        } else if bgs.count > 1 {
+            deltas.append(bgs[bgs.count - 1].sgv - bgs[bgs.count - 2].sgv)
+            // Set remainder to match the last delta we have
+            deltas.append(bgs[bgs.count - 1].sgv - bgs[bgs.count - 2].sgv)
+            deltas.append(bgs[bgs.count - 1].sgv - bgs[bgs.count - 2].sgv)
+        } else {
+            // We only have 1 reading, set all to 0.
+            deltas.append(0)
+            deltas.append(0)
+            deltas.append(0)
+        }
+        
+        
+        let currentBGTime = bgs[bgs.count - 1].date
+        var alarmTriggered = false
+        var numLoops = 0
+        checkQuietHours()
+        clearOldSnoozes()
+        
+        // Exit if all is snoozed
+        // still send persistent notification with all snoozed
+        if UserDefaultsRepository.alertSnoozeAllIsSnoozed.value {
+            persistentNotification(bgTime: currentBGTime)
+            return
+        }
+        
+        
+        // BG Based Alarms
+        // Check to make sure it is a current reading and has not already triggered alarm from this reading
+        if now - currentBGTime <= (5*60) && currentBGTime > UserDefaultsRepository.snoozedBGReadingTime.value as! TimeInterval {
+            
+            // trigger temporary alert first
+            if UserDefaultsRepository.alertTemporaryActive.value {
+                if UserDefaultsRepository.alertTemporaryBelow.value {
+                    if Float(currentBG) < UserDefaultsRepository.alertTemporaryBG.value {
+                        UserDefaultsRepository.alertTemporaryActive.value = false
+                        AlarmSound.whichAlarm = "Temporary Alert"
+                        if UserDefaultsRepository.alertTemporaryBGRepeat.value { numLoops = -1 }
+                        triggerAlarm(sound: UserDefaultsRepository.alertTemporarySound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops)
+                        return
+                    }
+                } else{
+                    if Float(currentBG) > UserDefaultsRepository.alertTemporaryBG.value {
+                        tabBarController?.selectedIndex = 2
+                        AlarmSound.whichAlarm = "Temporary Alert"
+                        if UserDefaultsRepository.alertTemporaryBGRepeat.value { numLoops = -1 }
+                        triggerAlarm(sound: UserDefaultsRepository.alertTemporarySound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops)
+                        return
+                    }
+                }
+            }
+            
+            // Check Urgent Low
+            if UserDefaultsRepository.alertUrgentLowActive.value && !UserDefaultsRepository.alertUrgentLowIsSnoozed.value &&
+                Float(currentBG) <= UserDefaultsRepository.alertUrgentLowBG.value {
+                // Separating this makes it so the low or drop alerts won't trigger if they already snoozed the urgent low
+                if !UserDefaultsRepository.alertUrgentLowIsSnoozed.value {
+                    AlarmSound.whichAlarm = "Urgent Low Alert"
+                    //determine if it is day or night and what should happen
+                    if UserDefaultsRepository.nightTime.value {
+                        if UserDefaultsRepository.alertUrgentLowNightTime.value {
+                            numLoops = -1
+                        }
+                    } else {
+                        if UserDefaultsRepository.alertUrgentLowDayTime.value {
+                            numLoops = -1
+                        }
+                    }
+                    triggerAlarm(sound: UserDefaultsRepository.alertUrgentLowSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertUrgentLowSnooze.value)
+                    return
+                } else {
+                    return
+                }
+            }
+            
+            // Check Low
+            if UserDefaultsRepository.alertLowActive.value && !UserDefaultsRepository.alertUrgentLowIsSnoozed.value &&
+                Float(currentBG) <= UserDefaultsRepository.alertLowBG.value && !UserDefaultsRepository.alertLowIsSnoozed.value {
+                AlarmSound.whichAlarm = "Low Alert"
+  
+                //determine if it is day or night and what should happen
+                if UserDefaultsRepository.nightTime.value {
+                    if UserDefaultsRepository.alertLowNightTime.value {
+                        numLoops = -1
+                    }
+                } else {
+                    if UserDefaultsRepository.alertLowDayTime.value {
+                        numLoops = -1
+                    }
+                }
+                
+                triggerAlarm(sound: UserDefaultsRepository.alertLowSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertLowSnooze.value)
+                return
+            }
+            
+            // Check Urgent High
+            if UserDefaultsRepository.alertUrgentHighActive.value && !UserDefaultsRepository.alertUrgentHighIsSnoozed.value &&
+                Float(currentBG) >= UserDefaultsRepository.alertUrgentHighBG.value {
+                // Separating this makes it so the high or rise alerts won't trigger if they already snoozed the urgent high
+                if !UserDefaultsRepository.alertUrgentHighIsSnoozed.value {
+                    AlarmSound.whichAlarm = "Urgent High Alert"
+                    //determine if it is day or night and what should happen
+                    if UserDefaultsRepository.nightTime.value {
+                        if UserDefaultsRepository.alertUrgentHighNightTime.value {
+                            numLoops = -1
+                        }
+                    } else {
+                        if UserDefaultsRepository.alertUrgentHighDayTime.value {
+                            numLoops = -1
+                        }
+                    }
+                    triggerAlarm(sound: UserDefaultsRepository.alertUrgentHighSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertUrgentHighSnooze.value)
+                    return
+                } else {
+                    return
+                }
+                
+            }
+            
+            // Check High
+            let persistentReadings = Int(UserDefaultsRepository.alertHighPersistent.value / 5)
+            let persistentBG = bgData[bgData.count - 1 - persistentReadings].sgv
+            if UserDefaultsRepository.alertHighActive.value &&
+                !UserDefaultsRepository.alertHighIsSnoozed.value &&
+                Float(currentBG) >= UserDefaultsRepository.alertHighBG.value &&
+                Float(persistentBG) >= UserDefaultsRepository.alertHighBG.value &&
+                !UserDefaultsRepository.alertHighIsSnoozed.value {
+                AlarmSound.whichAlarm = "High Alert"
+                //determine if it is day or night and what should happen
+                if UserDefaultsRepository.nightTime.value {
+                    if UserDefaultsRepository.alertHighNightTime.value {
+                        numLoops = -1
+                    }
+                } else {
+                    if UserDefaultsRepository.alertHighDayTime.value {
+                        numLoops = -1
+                    }
+                }
+                triggerAlarm(sound: UserDefaultsRepository.alertHighSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertHighSnooze.value)
+                return
+            }
+            
+            
+            
+            // Check Fast Drop
+            if UserDefaultsRepository.alertFastDropActive.value && !UserDefaultsRepository.alertFastDropIsSnoozed.value {
+                // make sure limit is off or BG is below value
+                if (!UserDefaultsRepository.alertFastDropUseLimit.value) || (UserDefaultsRepository.alertFastDropUseLimit.value && Float(currentBG) < UserDefaultsRepository.alertFastDropBelowBG.value) {
+                    let compare = 0 - UserDefaultsRepository.alertFastDropDelta.value
+                    
+                    //check last 2/3/4 readings
+                    if (UserDefaultsRepository.alertFastDropReadings.value == 2 && Float(deltas[0]) <= compare)
+                        || (UserDefaultsRepository.alertFastDropReadings.value == 3 && Float(deltas[0]) <= compare && Float(deltas[1]) <= compare)
+                        || (UserDefaultsRepository.alertFastDropReadings.value == 4 && Float(deltas[0]) <= compare && Float(deltas[1]) <= compare && Float(deltas[2]) <= compare) {
+                        AlarmSound.whichAlarm = "Fast Drop Alert"
+                        //determine if it is day or night and what should happen
+                        if UserDefaultsRepository.nightTime.value {
+                            if UserDefaultsRepository.alertFastDropNightTime.value {
+                                numLoops = -1
+                            }
+                        } else {
+                            if UserDefaultsRepository.alertFastDropDayTime.value {
+                                numLoops = -1
+                            }
+                        }
+                        triggerAlarm(sound: UserDefaultsRepository.alertFastDropSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertFastDropSnooze.value)
+                        return
+                    }
+                }
+            }
+            
+            // Check Fast Rise
+            if UserDefaultsRepository.alertFastRiseActive.value && !UserDefaultsRepository.alertFastRiseIsSnoozed.value {
+                // make sure limit is off or BG is above value
+                if (!UserDefaultsRepository.alertFastRiseUseLimit.value) || (UserDefaultsRepository.alertFastRiseUseLimit.value && Float(currentBG) > UserDefaultsRepository.alertFastRiseAboveBG.value) {
+                    let compare = UserDefaultsRepository.alertFastDropDelta.value
+                    
+                    //check last 2/3/4 readings
+                    if (UserDefaultsRepository.alertFastRiseReadings.value == 2 && Float(deltas[0]) >= compare)
+                        || (UserDefaultsRepository.alertFastRiseReadings.value == 3 && Float(deltas[0]) >= compare && Float(deltas[1]) >= compare)
+                        || (UserDefaultsRepository.alertFastRiseReadings.value == 4 && Float(deltas[0]) >= compare && Float(deltas[1]) >= compare && Float(deltas[2]) >= compare) {
+                        AlarmSound.whichAlarm = "Fast Rise Alert"
+                        //determine if it is day or night and what should happen
+                        if UserDefaultsRepository.nightTime.value {
+                            if UserDefaultsRepository.alertFastRiseNightTime.value {
+                                numLoops = -1
+                            }
+                        } else {
+                            if UserDefaultsRepository.alertFastRiseDayTime.value {
+                                numLoops = -1
+                            }
+                        }
+                        triggerAlarm(sound: UserDefaultsRepository.alertFastRiseSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertFastRiseSnooze.value)
+                        return
+                    }
+                }
+            }
+            
+            
+            
+        }
+        
+        // These only get checked and fire if a BG reading doesn't fire
+        
+        //check for missed reading alert
+        if UserDefaultsRepository.alertMissedReadingActive.value && !UserDefaultsRepository.alertMissedReadingIsSnoozed.value && (Double(now - currentBGTime) >= Double(UserDefaultsRepository.alertMissedReading.value * 60)) {
+            AlarmSound.whichAlarm = "Missed Reading Alert"
+            //determine if it is day or night and what should happen
+            if UserDefaultsRepository.nightTime.value {
+                if UserDefaultsRepository.alertMissedReadingNightTime.value {
+                    numLoops = -1
+                }
+            } else {
+                if UserDefaultsRepository.alertMissedReadingDayTime.value {
+                    numLoops = -1
+                }
+            }
+            triggerAlarm(sound: UserDefaultsRepository.alertMissedReadingSound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertMissedReadingSnooze.value)
+            return
+        }
+        
+        //check for not looping alert
+        if UserDefaultsRepository.url.value != "" {
+            
+            if UserDefaultsRepository.alertNotLoopingActive.value
+                && !UserDefaultsRepository.alertNotLoopingIsSnoozed.value
+                && (Double(dateTimeUtils.getNowTimeIntervalUTC() - UserDefaultsRepository.alertLastLoopTime.value) >= Double(UserDefaultsRepository.alertNotLooping.value * 60))
+                && UserDefaultsRepository.alertLastLoopTime.value > 0 {
+                
+                var trigger = true
+                if (UserDefaultsRepository.alertNotLoopingUseLimits.value
+                    && (
+                        (Float(currentBG) >= UserDefaultsRepository.alertNotLoopingUpperLimit.value
+                            && Float(currentBG) <= UserDefaultsRepository.alertNotLoopingLowerLimit.value) ||
+                            // Ignore Limits if BG reading is older than non looping time
+                            (Double(now - currentBGTime) >= Double(UserDefaultsRepository.alertNotLooping.value * 60))
+                    ) ||
+                    !UserDefaultsRepository.alertNotLoopingUseLimits.value) {
+                    AlarmSound.whichAlarm = "Not Looping Alert"
+                    //determine if it is day or night and what should happen
+                    if UserDefaultsRepository.nightTime.value {
+                        if UserDefaultsRepository.alertNotLoopingNightTime.value {
+                            numLoops = -1
+                        }
+                    } else {
+                        if UserDefaultsRepository.alertNotLoopingDayTime.value {
+                            numLoops = -1
+                        }
+                    }
+                    triggerAlarm(sound: UserDefaultsRepository.alertNotLoopingSound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertNotLoopingSnooze.value)
+                    return
+                }
+            }
+            
+            // check for missed bolus - Only checks within 1 hour of carb entry
+            // Only continue if alert is active, not snooozed, we have carb data, and bg is over the ignore limit
+            if UserDefaultsRepository.alertMissedBolusActive.value
+                && !UserDefaultsRepository.alertMissedBolusIsSnoozed.value
+                && carbData.count > 0
+                && Float(currentBG) > UserDefaultsRepository.alertMissedBolusLowGramsBG.value {
+                
+                // Grab the latest carb entry
+                let lastCarb = carbData[carbData.count - 1].value
+                let lastCarbTime = carbData[carbData.count - 1].date
+                let now = dateTimeUtils.getNowTimeIntervalUTC()
+                
+                //Make sure carb entry is newer than 1 hour, has reached the time length, and is over the ignore limit
+                if lastCarbTime > (now - (60 * 60))
+                    && lastCarbTime < (now - Double((UserDefaultsRepository.alertMissedBolus.value * 60)))
+                    && lastCarb > Double(UserDefaultsRepository.alertMissedBolusLowGrams.value) {
+                    
+                    // There is a current carb but no boluses data at all
+                    if bolusData.count < 1 {
+                        AlarmSound.whichAlarm = "Missed Bolus Alert"
+                        //determine if it is day or night and what should happen
+                        if UserDefaultsRepository.nightTime.value {
+                            if UserDefaultsRepository.alertMissedBolusNightTime.value {
+                                numLoops = -1
+                            }
+                        } else {
+                            if UserDefaultsRepository.alertMissedBolusDayTime.value {
+                                numLoops = -1
+                            }
+                        }
+                        triggerAlarm(sound: UserDefaultsRepository.alertMissedBolusSound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertMissedBolusSnooze.value)
+                        return
+                    }
+                    
+                    // Get the latest bolus over the small bolus exclusion
+                    // Start with 0.0 bolus assuming there isn't one to cause a trigger and only add one if found
+                    var lastBolus = 0.0
+                    var lastBolusTime = 0.0
+                    var i = 1
+                    // check the boluses in reverse order setting it only if the time is after the carb time minus prebolus time.
+                    // This will make the loop stop at the most recent bolus that is over the minimum value or continue through all boluses
+                    while lastBolus < UserDefaultsRepository.alertMissedBolusIgnoreBolus.value && i <= bolusData.count {
+                        // Set the bolus if it's after the carb time minus prebolus time
+                        if (bolusData[bolusData.count - i].date >= lastCarbTime - Double(UserDefaultsRepository.alertMissedBolusPrebolus.value * 60)) {
+                            lastBolus = bolusData[bolusData.count - i].value
+                            lastBolusTime = bolusData[bolusData.count - i].date
+                        }
+                        i += 1
+                    }
+                    
+                    // This will trigger is no boluses were set above
+                    if (lastBolus == 0.0) {
+                        AlarmSound.whichAlarm = "Missed Bolus Alert"
+                        //determine if it is day or night and what should happen
+                        if UserDefaultsRepository.nightTime.value {
+                            if UserDefaultsRepository.alertMissedBolusNightTime.value {
+                                numLoops = -1
+                            }
+                        } else {
+                            if UserDefaultsRepository.alertMissedBolusDayTime.value {
+                                numLoops = -1
+                            }
+                        }
+                        triggerAlarm(sound: UserDefaultsRepository.alertMissedBolusSound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertMissedBolusSnooze.value)
+                        return
+                    }
+                    
+                }
+                
+            }
+            
+            // Check Sage
+            if UserDefaultsRepository.alertSAGEActive.value && !UserDefaultsRepository.alertSAGEIsSnoozed.value {
+                let insertTime = Double(UserDefaultsRepository.alertSageInsertTime.value)
+                let alertDistance = Double(UserDefaultsRepository.alertSAGE.value * 60 * 60)
+                let delta = now - insertTime
+                let tenDays = 10 * 24 * 60 * 60
+                if Double(tenDays) - Double(delta) <= alertDistance {
+                    AlarmSound.whichAlarm = "Sensor Change Alert"
+                    //determine if it is day or night and what should happen
+                    if UserDefaultsRepository.nightTime.value {
+                        if UserDefaultsRepository.alertSAGENightTime.value {
+                            numLoops = -1
+                        }
+                    } else {
+                        if UserDefaultsRepository.alertSAGEDayTime.value {
+                            numLoops = -1
+                        }
+                    }
+                    triggerAlarm(sound: UserDefaultsRepository.alertSAGESound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertSAGESnooze.value, snoozeIncrement: 1)
+                    return
+                }
+            }
+            
+            // Check Cage
+            if UserDefaultsRepository.alertCAGEActive.value && !UserDefaultsRepository.alertCAGEIsSnoozed.value {
+                let insertTime = Double(UserDefaultsRepository.alertCageInsertTime.value)
+                let alertDistance = Double(UserDefaultsRepository.alertCAGE.value * 60 * 60)
+                let delta = now - insertTime
+                let tenDays = 3 * 24 * 60 * 60
+                if Double(tenDays) - Double(delta) <= alertDistance {
+                    AlarmSound.whichAlarm = "Pump Change Alert"
+                    //determine if it is day or night and what should happen
+                    if UserDefaultsRepository.nightTime.value {
+                        if UserDefaultsRepository.alertCAGENightTime.value {
+                            numLoops = -1
+                        }
+                    } else {
+                        if UserDefaultsRepository.alertCAGEDayTime.value {
+                            numLoops = -1
+                        }
+                    }
+                    triggerAlarm(sound: UserDefaultsRepository.alertCAGESound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertCAGESnooze.value, snoozeIncrement: 1)
+                    return
+                }
+            }
+            
+            // Check Pump
+            if UserDefaultsRepository.alertPump.value && !UserDefaultsRepository.alertPumpIsSnoozed.value {
+                let alertAt = Double(UserDefaultsRepository.alertPumpAt.value)
+                if latestPumpVolume <= alertAt {
+                    AlarmSound.whichAlarm = "Low Insulin Alert"
+                    //determine if it is day or night and what should happen
+                    if UserDefaultsRepository.nightTime.value {
+                        if UserDefaultsRepository.alertPumpNightTime.value {
+                            numLoops = -1
+                        }
+                    } else {
+                        if UserDefaultsRepository.alertPumpDayTime.value {
+                            numLoops = -1
+                        }
+                    }
+                    triggerAlarm(sound: UserDefaultsRepository.alertPumpSound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertPumpSnoozeHours.value, snoozeIncrement: 1)
+                    return
+                }
+            }
+        }
+        
+        
+        
+        
+        // still send persistent notification if no alarms trigger and persistent notification is on
+        persistentNotification(bgTime: currentBGTime)
+        
+    }
+       
+    func checkOverrideAlarms()
+    {
+        if UserDefaultsRepository.alertSnoozeAllIsSnoozed.value { return }
+        
+        let recentOverride = overrideGraphData.last
+        let recentStart: TimeInterval = recentOverride?.date ?? 0
+        let recentEnd: TimeInterval = recentOverride?.endDate ?? 0
+        let now = dateTimeUtils.getNowTimeIntervalUTC()
+        
+        var triggerStart = false
+        var triggerEnd = false
+        
+        // Trigger newly started override
+        if now - recentStart > 0 && now - recentStart <= (15 * 60) && recentStart > lastOverrideAlarm {
+            triggerStart = true
+        } else if now - recentEnd > 0 && now - recentEnd <= (15 * 60) && recentEnd > lastOverrideAlarm {
+            triggerEnd = true
+        } else {
+            return
+        }
+        
+        let overrideName = recentOverride?.reason as! String
+       
+        var numLoops = 0
+        if UserDefaultsRepository.alertOverrideStart.value && !UserDefaultsRepository.alertOverrideStartIsSnoozed.value && triggerStart {
+            AlarmSound.whichAlarm = overrideName + " Override Started"
+            //determine if it is day or night and what should happen
+            if UserDefaultsRepository.nightTime.value {
+                if UserDefaultsRepository.alertOverrideStartNightTime.value {
+                    numLoops = -1
+                }
+            } else {
+                if UserDefaultsRepository.alertOverrideStartDayTime.value {
+                    numLoops = -1
+                }
+            }
+                triggerOneTimeAlarm(sound: UserDefaultsRepository.alertOverrideStartSound.value, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops)
+                lastOverrideStartTime = recentStart
+                lastOverrideAlarm = now
+        } else if UserDefaultsRepository.alertOverrideEnd.value && !UserDefaultsRepository.alertOverrideEndIsSnoozed.value && triggerEnd {
+                AlarmSound.whichAlarm = overrideName + " Override Ended"
+            //determine if it is day or night and what should happen
+            if UserDefaultsRepository.nightTime.value {
+                if UserDefaultsRepository.alertOverrideEndNightTime.value {
+                    numLoops = -1
+                }
+            } else {
+                if UserDefaultsRepository.alertOverrideEndDayTime.value {
+                    numLoops = -1
+                }
+            }
+                triggerOneTimeAlarm(sound: UserDefaultsRepository.alertOverrideEndSound.value, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops)
+                lastOverrideEndTime = recentEnd
+                lastOverrideAlarm = now
+        }
+    }
+    
+    func triggerOneTimeAlarm(sound: String, overrideVolume: Bool, numLoops: Int)
+    {
+        guard let snoozer = self.tabBarController!.viewControllers?[2] as? SnoozeViewController else { return }
+        snoozer.updateDisplayWhenTriggered(bgVal: bgUnits.toDisplayUnits(String(bgData[bgData.count - 1].sgv)), directionVal: latestDirectionString ?? "", deltaVal: bgUnits.toDisplayUnits(latestDeltaString) ?? "", minAgoVal: latestMinAgoString ?? "", alertLabelVal: AlarmSound.whichAlarm)
+        AlarmSound.setSoundFile(str: sound)
+        AlarmSound.play(overrideVolume: overrideVolume, numLoops: numLoops)
+        startAlarmPlayingTimer()
+    }
+    
+    func triggerAlarm(sound: String, snooozedBGReadingTime: TimeInterval?, overrideVolume: Bool, numLoops: Int, snoozeTime: Int = 0, snoozeIncrement: Int = 5)
+    {
+        guard let snoozer = self.tabBarController!.viewControllers?[2] as? SnoozeViewController else { return }
+        snoozer.updateDisplayWhenTriggered(bgVal: bgUnits.toDisplayUnits(String(bgData[bgData.count - 1].sgv)), directionVal: latestDirectionString ?? "", deltaVal: bgUnits.toDisplayUnits(latestDeltaString) ?? "", minAgoVal: latestMinAgoString ?? "", alertLabelVal: AlarmSound.whichAlarm)
+        snoozer.SnoozeButton.isHidden = false
+        snoozer.AlertLabel.isHidden = false
+        snoozer.clockLabel.isHidden = true
+        snoozer.debugTextView.isHidden = true
+        snoozer.snoozeForMinuteLabel.text = String(snoozeTime)
+        snoozer.snoozeForMinuteStepper.value = Double(snoozeTime)
+        snoozer.snoozeForMinuteStepper.stepValue = Double(snoozeIncrement)
+        if snoozeTime != 0 {
+            snoozer.snoozeForMinuteStepper.isHidden = false
+            snoozer.snoozeForMinuteLabel.isHidden = false
+        }
+        
+        tabBarController?.selectedIndex = 2
+        if snooozedBGReadingTime != nil {
+            UserDefaultsRepository.snoozedBGReadingTime.value = snooozedBGReadingTime
+        }
+        AlarmSound.setSoundFile(str: sound)
+        AlarmSound.play(overrideVolume: overrideVolume, numLoops: numLoops)
+        
+        let bgSeconds = bgData.last!.date
+        let now = Date().timeIntervalSince1970
+        let secondsAgo = now - bgSeconds
+        var timerLength = 290 - secondsAgo
+        if timerLength < 10 { timerLength = 290}
+        startAlarmPlayingTimer(time: timerLength)
+    }
+    
+    func stopAlarmAtNextReading(){
+        
+        AlarmSound.whichAlarm = "none"
+        guard let snoozer = self.tabBarController!.viewControllers?[2] as? SnoozeViewController else { return }
+        snoozer.updateDisplayWhenTriggered(bgVal: bgUnits.toDisplayUnits(String(bgData[bgData.count - 1].sgv)), directionVal: latestDirectionString ?? "", deltaVal: bgUnits.toDisplayUnits(latestDeltaString) ?? "", minAgoVal: latestMinAgoString ?? "", alertLabelVal: AlarmSound.whichAlarm)
+        snoozer.SnoozeButton.isHidden = true
+        snoozer.AlertLabel.isHidden = true
+        AlarmSound.stop()
+    }
+    
+    func clearOldSnoozes(){
+          let date = Date()
+          let now = date.timeIntervalSince1970
+          var needsReload: Bool = false
+          guard let alarms = self.tabBarController!.viewControllers?[1] as? AlarmViewController else { return }
+          
+          if date > UserDefaultsRepository.alertSnoozeAllTime.value ?? date {
+              UserDefaultsRepository.alertSnoozeAllTime.setNil(key: "alertSnoozeAllTime")
+              UserDefaultsRepository.alertSnoozeAllIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertSnoozeAllTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertSnoozeAllIsSnoozed", value: false)
+            
+          }
+          
+          if date > UserDefaultsRepository.alertUrgentLowSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertUrgentLowSnoozedTime.setNil(key: "alertUrgentLowSnoozedTime")
+              UserDefaultsRepository.alertUrgentLowIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertUrgentLowSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertUrgentLowIsSnoozed", value: false)
+            
+          }
+          if date > UserDefaultsRepository.alertLowSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertLowSnoozedTime.setNil(key: "alertLowSnoozedTime")
+              UserDefaultsRepository.alertLowIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertLowSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertLowIsSnoozed", value: false)
+         
+          }
+          if date > UserDefaultsRepository.alertHighSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertHighSnoozedTime.setNil(key: "alertHighSnoozedTime")
+              UserDefaultsRepository.alertHighIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertHighSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertHighIsSnoozed", value: false)
+            
+          }
+          if date > UserDefaultsRepository.alertUrgentHighSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertUrgentHighSnoozedTime.setNil(key: "alertUrgentHighSnoozedTime")
+              UserDefaultsRepository.alertUrgentHighIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertUrgentHighSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertUrgentHighIsSnoozed", value: false)
+            
+          }
+          if date > UserDefaultsRepository.alertFastDropSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertFastDropSnoozedTime.setNil(key: "alertFastDropSnoozedTime")
+              UserDefaultsRepository.alertFastDropIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertFastDropSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertFastDropIsSnoozed", value: false)
+             
+          }
+          if date > UserDefaultsRepository.alertFastRiseSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertFastRiseSnoozedTime.setNil(key: "alertFastRiseSnoozedTime")
+              UserDefaultsRepository.alertFastRiseIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertFastRiseSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertFastRiseIsSnoozed", value: false)
+             
+          }
+          if date > UserDefaultsRepository.alertMissedReadingSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertMissedReadingSnoozedTime.setNil(key: "alertMissedReadingSnoozedTime")
+              UserDefaultsRepository.alertMissedReadingIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertMissedReadingSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertMissedReadingIsSnoozed", value: false)
+            
+          }
+          if date > UserDefaultsRepository.alertNotLoopingSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertNotLoopingSnoozedTime.setNil(key: "alertNotLoopingSnoozedTime")
+              UserDefaultsRepository.alertNotLoopingIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertNotLoopingSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertNotLoopingIsSnoozed", value: false)
+           
+              
+          }
+          if date > UserDefaultsRepository.alertMissedBolusSnoozedTime.value ?? date {
+              UserDefaultsRepository.alertMissedBolusSnoozedTime.setNil(key: "alertMissedBolusSnoozedTime")
+              UserDefaultsRepository.alertMissedBolusIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertMissedBolusSnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertMissedBolusIsSnoozed", value: false)
+
+          }
+          if date > UserDefaultsRepository.alertSAGESnoozedTime.value ?? date {
+              UserDefaultsRepository.alertSAGESnoozedTime.setNil(key: "alertSAGESnoozedTime")
+              UserDefaultsRepository.alertSAGEIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertSAGESnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertSAGEIsSnoozed", value: false)
+    
+          }
+          if date > UserDefaultsRepository.alertCAGESnoozedTime.value ?? date {
+              UserDefaultsRepository.alertCAGESnoozedTime.setNil(key: "alertCAGESnoozedTime")
+              UserDefaultsRepository.alertCAGEIsSnoozed.value = false
+              alarms.reloadSnoozeTime(key: "alertCAGESnoozedTime", setNil: true)
+              alarms.reloadIsSnoozed(key: "alertCAGEIsSnoozed", value: false)
+
+          }
+        if date > UserDefaultsRepository.alertOverrideStartSnoozedTime.value ?? date {
+            UserDefaultsRepository.alertOverrideStartSnoozedTime.setNil(key: "alertOverrideStartSnoozedTime")
+            UserDefaultsRepository.alertOverrideStartIsSnoozed.value = false
+            alarms.reloadSnoozeTime(key: "alertOverrideStartSnoozedTime", setNil: true)
+            alarms.reloadIsSnoozed(key: "alertOverrideStartIsSnoozed", value: false)
+        }
+        if date > UserDefaultsRepository.alertOverrideEndSnoozedTime.value ?? date {
+            UserDefaultsRepository.alertOverrideEndSnoozedTime.setNil(key: "alertOverrideEndSnoozedTime")
+            UserDefaultsRepository.alertOverrideEndIsSnoozed.value = false
+            alarms.reloadSnoozeTime(key: "alertOverrideEndSnoozedTime", setNil: true)
+            alarms.reloadIsSnoozed(key: "alertOverrideEndIsSnoozed", value: false)
+
+        }
+        
+        if date > UserDefaultsRepository.alertPumpSnoozedTime.value ?? date {
+            UserDefaultsRepository.alertPumpSnoozedTime.setNil(key: "alertPumpSnoozedTime")
+            UserDefaultsRepository.alertPumpIsSnoozed.value = false
+            alarms.reloadSnoozeTime(key: "alertPumpSnoozedTime", setNil: true)
+            alarms.reloadIsSnoozed(key: "alertPumpIsSnoozed", value: false)
+
+        }
+        
+        
+      }
+    
+    func checkQuietHours() {
+        if UserDefaultsRepository.quietHourStart.value == nil || UserDefaultsRepository.quietHourEnd.value == nil { return }
+        
+        var startDateComponents = DateComponents()
+        
+        let today = Date()
+        let todayCalendar = Calendar.current
+        let month = todayCalendar.component(.month, from: today)
+        let day = todayCalendar.component(.day, from: today)
+        let year = todayCalendar.component(.year, from: today)
+        let hour = todayCalendar.component(.hour, from: today)
+        let minute = todayCalendar.component(.minute, from: today)
+        let todayMinutes = (60 * hour) + minute
+        
+        let start = UserDefaultsRepository.quietHourStart.value
+        let startCalendar = Calendar.current
+        let startHour = startCalendar.component(.hour, from: start!)
+        let startMinute = startCalendar.component(.minute, from: start!)
+        let startMinutes = (60 * startHour) + startMinute
+        
+        if todayMinutes >= startMinutes {
+            let tomorrow = Date().addingTimeInterval(86400)
+            let tomorrowCalendar = Calendar.current
+            let end = UserDefaultsRepository.quietHourEnd.value
+            let endCalendar = Calendar.current
+            
+            var components = DateComponents()
+            components.month = tomorrowCalendar.component(.month, from: tomorrow)
+            components.day = tomorrowCalendar.component(.day, from: tomorrow)
+            components.year = tomorrowCalendar.component(.year, from: tomorrow)
+            components.hour = endCalendar.component(.hour, from: end!)
+            components.minute = endCalendar.component(.minute, from: end!)
+            components.second = endCalendar.component(.second, from: end!)
+            let snoozeCalendar = Calendar.current
+            let snoozeTime = snoozeCalendar.date(from: components)
+            
+            guard let snoozer = self.tabBarController!.viewControllers?[2] as? SnoozeViewController else { return }
+            snoozer.setQuietHours(snoozeTime: snoozeTime!)
+            UserDefaultsRepository.nightTime.value = true
+        } else {
+            UserDefaultsRepository.nightTime.value = false
+        }
+        
+    }
+    
+    
+    func speakBG(sgv: Int) {
+           var speechSynthesizer = AVSpeechSynthesizer()
+           var speechUtterance: AVSpeechUtterance = AVSpeechUtterance(string: "Current BG is " + bgUnits.toDisplayUnits(String(sgv)))
+           speechUtterance.rate = AVSpeechUtteranceMaximumSpeechRate / 2
+           speechUtterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+           speechSynthesizer.speak(speechUtterance)
+       }
+    
+}

--- a/LoopFollow/Controllers/Alarms.swift
+++ b/LoopFollow/Controllers/Alarms.swift
@@ -90,7 +90,9 @@ extension MainViewController {
                 // Separating this makes it so the low or drop alerts won't trigger if they already snoozed the urgent low
                 if !UserDefaultsRepository.alertUrgentLowIsSnoozed.value {
                     AlarmSound.whichAlarm = "Urgent Low Alert"
-                    if UserDefaultsRepository.alertUrgentLowRepeat.value { numLoops = -1 }
+                    if UserDefaultsRepository.alertUrgentLowRepeat.value || (UserDefaultsRepository.alertsRepeatDuringQH.value && UserDefaultsRepository.checkIfQuietHours.value) {
+                        numLoops = -1
+                        }
                     triggerAlarm(sound: UserDefaultsRepository.alertUrgentLowSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertUrgentLowSnooze.value)
                     return
                 } else {
@@ -102,7 +104,9 @@ extension MainViewController {
             if UserDefaultsRepository.alertLowActive.value && !UserDefaultsRepository.alertUrgentLowIsSnoozed.value &&
                 Float(currentBG) <= UserDefaultsRepository.alertLowBG.value && !UserDefaultsRepository.alertLowIsSnoozed.value {
                 AlarmSound.whichAlarm = "Low Alert"
-                if UserDefaultsRepository.alertLowRepeat.value { numLoops = -1 }
+                if UserDefaultsRepository.alertLowRepeat.value || (UserDefaultsRepository.alertsRepeatDuringQH.value && UserDefaultsRepository.checkIfQuietHours.value) {
+                    numLoops = -1
+                    }
                 triggerAlarm(sound: UserDefaultsRepository.alertLowSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertLowSnooze.value)
                 return
             }
@@ -113,7 +117,9 @@ extension MainViewController {
                 // Separating this makes it so the high or rise alerts won't trigger if they already snoozed the urgent high
                 if !UserDefaultsRepository.alertUrgentHighIsSnoozed.value {
                     AlarmSound.whichAlarm = "Urgent High Alert"
-                    if UserDefaultsRepository.alertUrgentHighRepeat.value { numLoops = -1 }
+                    if UserDefaultsRepository.alertUrgentHighRepeat.value || (UserDefaultsRepository.alertsRepeatDuringQH.value && UserDefaultsRepository.checkIfQuietHours.value) {
+                        numLoops = -1
+                        }
                     triggerAlarm(sound: UserDefaultsRepository.alertUrgentHighSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertUrgentHighSnooze.value)
                     return
                 } else {
@@ -131,7 +137,9 @@ extension MainViewController {
                 Float(persistentBG) >= UserDefaultsRepository.alertHighBG.value &&
                 !UserDefaultsRepository.alertHighIsSnoozed.value {
                 AlarmSound.whichAlarm = "High Alert"
-                if UserDefaultsRepository.alertHighRepeat.value { numLoops = -1 }
+                if UserDefaultsRepository.alertHighRepeat.value || (UserDefaultsRepository.alertsRepeatDuringQH.value && UserDefaultsRepository.checkIfQuietHours.value) {
+                    numLoops = -1
+                    }
                 triggerAlarm(sound: UserDefaultsRepository.alertHighSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertHighSnooze.value)
                 return
             }
@@ -149,7 +157,9 @@ extension MainViewController {
                         || (UserDefaultsRepository.alertFastDropReadings.value == 3 && Float(deltas[0]) <= compare && Float(deltas[1]) <= compare)
                         || (UserDefaultsRepository.alertFastDropReadings.value == 4 && Float(deltas[0]) <= compare && Float(deltas[1]) <= compare && Float(deltas[2]) <= compare) {
                         AlarmSound.whichAlarm = "Fast Drop Alert"
-                        if UserDefaultsRepository.alertFastDropRepeat.value { numLoops = -1 }
+                        if UserDefaultsRepository.alertFastDropRepeat.value || (UserDefaultsRepository.alertsRepeatDuringQH.value && UserDefaultsRepository.checkIfQuietHours.value) {
+                            numLoops = -1
+                            }
                         triggerAlarm(sound: UserDefaultsRepository.alertFastDropSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertFastDropSnooze.value)
                         return
                     }
@@ -167,7 +177,9 @@ extension MainViewController {
                         || (UserDefaultsRepository.alertFastRiseReadings.value == 3 && Float(deltas[0]) >= compare && Float(deltas[1]) >= compare)
                         || (UserDefaultsRepository.alertFastRiseReadings.value == 4 && Float(deltas[0]) >= compare && Float(deltas[1]) >= compare && Float(deltas[2]) >= compare) {
                         AlarmSound.whichAlarm = "Fast Rise Alert"
-                        if UserDefaultsRepository.alertFastRiseRepeat.value { numLoops = -1 }
+                        if UserDefaultsRepository.alertFastRiseRepeat.value || (UserDefaultsRepository.alertsRepeatDuringQH.value && UserDefaultsRepository.checkIfQuietHours.value) {
+                            numLoops = -1
+                            }
                         triggerAlarm(sound: UserDefaultsRepository.alertFastRiseSound.value, snooozedBGReadingTime: currentBGTime, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertFastRiseSnooze.value)
                         return
                     }
@@ -183,7 +195,9 @@ extension MainViewController {
         //check for missed reading alert
         if UserDefaultsRepository.alertMissedReadingActive.value && !UserDefaultsRepository.alertMissedReadingIsSnoozed.value && (Double(now - currentBGTime) >= Double(UserDefaultsRepository.alertMissedReading.value * 60)) {
             AlarmSound.whichAlarm = "Missed Reading Alert"
-            if UserDefaultsRepository.alertMissedReadingRepeat.value { numLoops = -1 }
+            if UserDefaultsRepository.alertMissedReadingRepeat.value || (UserDefaultsRepository.alertsRepeatDuringQH.value && UserDefaultsRepository.checkIfQuietHours.value) {
+                numLoops = -1
+                }
             triggerAlarm(sound: UserDefaultsRepository.alertMissedReadingSound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertMissedReadingSnooze.value)
             return
         }
@@ -206,7 +220,9 @@ extension MainViewController {
                     ) ||
                     !UserDefaultsRepository.alertNotLoopingUseLimits.value) {
                     AlarmSound.whichAlarm = "Not Looping Alert"
-                    if UserDefaultsRepository.alertNotLoopingRepeat.value { numLoops = -1 }
+                    if UserDefaultsRepository.alertNotLoopingRepeat.value || (UserDefaultsRepository.alertsRepeatDuringQH.value && UserDefaultsRepository.checkIfQuietHours.value) {
+                        numLoops = -1
+                        }
                     triggerAlarm(sound: UserDefaultsRepository.alertNotLoopingSound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertNotLoopingSnooze.value)
                     return
                 }
@@ -557,8 +573,15 @@ extension MainViewController {
             
             guard let snoozer = self.tabBarController!.viewControllers?[2] as? SnoozeViewController else { return }
             snoozer.setQuietHours(snoozeTime: snoozeTime!)
+            
+            if UserDefaultsRepository.alertsRepeatDuringQH.value {
+                UserDefaultsRepository.checkIfQuietHours.value = true
+            }
+        } else {
+            if UserDefaultsRepository.alertsRepeatDuringQH.value {
+                UserDefaultsRepository.checkIfQuietHours.value = false
+            }
         }
-        
     }
     
     

--- a/LoopFollow/ViewControllers/AlarmViewController.swift
+++ b/LoopFollow/ViewControllers/AlarmViewController.swift
@@ -2108,7 +2108,7 @@ class AlarmViewController: FormViewController {
                       UserDefaultsRepository.forcedOutputVolume.value = Float(value)
               }
             
-             +++ Section(header: "Quiet Hour Settings", footer: "Quiet hours can be used to automatically snooze non-critical alerts that you do not wish to be awakened for such as a sensor change pre-alert that may happen during the night.")  { row in
+             +++ Section(header: "Quiet Hour Settings", footer: "Quiet hours can be used to automatically snooze non-critical alerts that you do not wish to be awakened for such as a sensor change pre-alert that may happen during the night. Repeat Alerts forces critical alerts to repeat during quiet hours regardless of individual alarm settings.")  { row in
                 row.tag = "quietHourSection"
                         }
             <<< TimeInlineRow("quietHourStart") { row in
@@ -2127,6 +2127,16 @@ class AlarmViewController: FormViewController {
                 guard let value = row.value else { return }
                 UserDefaultsRepository.quietHourEnd.value = value
         }
+        
+        <<< SwitchRow("repeatAlarmsQH"){ row in
+                row.title = "Repeat Alerts"
+                row.value = UserDefaultsRepository.alertsRepeatDuringQH.value
+            
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.alertsRepeatDuringQH.value = value
+        }
+        
        }
 
 }

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -108,6 +108,8 @@ class UserDefaultsRepository {
     
     static let quietHourStart = UserDefaultsValue<Date?>(key: "quietHourStart", default: nil)
     static let quietHourEnd = UserDefaultsValue<Date?>(key: "quietHourEnd", default: nil)
+    static let alertsRepeatDuringQH = UserDefaultsValue<Bool>(key: "alertsRepeatDuringQH", default: false)
+    static let checkIfQuietHours = UserDefaultsValue<Bool>(key: "checkIfQuietHours", default: false)
     
     static let snoozedBGReadingTime = UserDefaultsValue<TimeInterval?>(key: "snoozedBGReadingTime", default: 0)
     

--- a/UserDefaults.swift
+++ b/UserDefaults.swift
@@ -1,0 +1,291 @@
+//
+//  UserDefaults.swift
+//  LoopFollow
+//
+//  Created by Jon Fawcett on 6/4/20.
+//  Copyright © 2020 Jon Fawcett. All rights reserved.
+//
+//
+
+
+import Foundation
+import UIKit
+
+class UserDefaultsRepository {
+
+    // DisplayValues total
+    static let infoDataTotal = UserDefaultsValue<Int>(key: "infoDataTotal", default: 0)
+    static let infoNames = UserDefaultsValue<[String]>(key: "infoNames", default: [
+        "IOB",
+        "COB",
+        "Basal",
+        "Override",
+        "Battery",
+        "Pump",
+        "SAGE",
+        "CAGE",
+        "Rec. Bolus",
+        "Pred."])
+    static let infoSort = UserDefaultsValue<[Int]>(key: "infoSort", default: [0,1,2,3,4,5,6,7,8,9])
+    static let infoVisible = UserDefaultsValue<[Bool]>(key: "infoVisible", default: [true,true,true,true,true,true,true,true,true,true])
+    
+    // Nightscout Settings
+    static let url = UserDefaultsValue<String>(key: "url", default: "")
+    static let token = UserDefaultsValue<String>(key: "token", default: "")
+    static let units = UserDefaultsValue<String>(key: "units", default: "mg/dL")
+    
+    // Dexcom Share Settings
+    static let shareUserName = UserDefaultsValue<String>(key: "shareUserName", default: "")
+    static let sharePassword = UserDefaultsValue<String>(key: "sharePassword", default: "")
+    static let shareServer = UserDefaultsValue<String>(key: "shareServer", default: "US")
+    
+    // Graph Settings
+    static let chartScaleX = UserDefaultsValue<Float>(key: "chartScaleX", default: 18.0)
+    static let showDots = UserDefaultsValue<Bool>(key: "showDots", default: true)
+    static let smallGraphTreatments = UserDefaultsValue<Bool>(key: "smallGraphTreatments", default: true)
+    static let showValues = UserDefaultsValue<Bool>(key: "showValues", default: true)
+    static let showAbsorption = UserDefaultsValue<Bool>(key: "showAbsorption", default: true)
+    static let showLines = UserDefaultsValue<Bool>(key: "showLines", default: true)
+    static let hoursToLoad = UserDefaultsValue<Int>(key: "hoursToLoad", default: 24)
+    static let predictionToLoad = UserDefaultsValue<Double>(key: "predictionToLoad", default: 1)
+    static let minBasalScale = UserDefaultsValue<Double>(key: "minBasalScale", default: 5.0)
+    static let minBGScale = UserDefaultsValue<Float>(key: "minBGScale", default: 250.0)
+    static let showDIALines = UserDefaultsValue<Bool>(key: "showDIAMarkers", default: true)
+    static let lowLine = UserDefaultsValue<Float>(key: "lowLine", default: 70.0)
+    static let highLine = UserDefaultsValue<Float>(key: "highLine", default: 180.0)
+    static let smallGraphHeight = UserDefaultsValue<Int>(key: "smallGraphHeight", default: 40)
+    
+    
+    // General Settings
+    static let colorBGText = UserDefaultsValue<Bool>(key: "colorBGText", default: true)
+    static let showStats = UserDefaultsValue<Bool>(key: "showStats", default: true)
+    static let useIFCC = UserDefaultsValue<Bool>(key: "useIFCC", default: false)
+    static let showSmallGraph = UserDefaultsValue<Bool>(key: "showSmallGraph", default: true)
+    static let speakBG = UserDefaultsValue<Bool>(key: "speakBG", default: false)
+    static let backgroundRefreshFrequency = UserDefaultsValue<Double>(key: "backgroundRefreshFrequency", default: 1)
+    static let backgroundRefresh = UserDefaultsValue<Bool>(key: "backgroundRefresh", default: true)
+    static let appBadge = UserDefaultsValue<Bool>(key: "appBadge", default: true)
+    static let dimScreenWhenIdle = UserDefaultsValue<Int>(key: "dimScreenWhenIdle", default: 0)
+    static let forceDarkMode = UserDefaultsValue<Bool>(key: "forceDarkMode", default: true)
+    static let persistentNotification = UserDefaultsValue<Bool>(key: "persistentNotification", default: false)
+    static let persistentNotificationLastBGTime = UserDefaultsValue<TimeInterval>(key: "persistentNotificationLastBGTime", default: 0)
+    static let screenlockSwitchState = UserDefaultsValue<Bool>(
+        key: "screenlockSwitchState",
+        default: UIApplication.shared.isIdleTimerDisabled,
+        onChange: { screenlock in
+            UIApplication.shared.isIdleTimerDisabled = screenlock
+    })
+    
+    // Advanced Settings
+    static let onlyDownloadBG = UserDefaultsValue<Bool>(key: "onlyDownloadBG", default: false)
+    static let downloadTreatments = UserDefaultsValue<Bool>(key: "downloadTreatments", default: true)
+    static let downloadPrediction = UserDefaultsValue<Bool>(key: "downloadPrediction", default: true)
+    static let graphOtherTreatments = UserDefaultsValue<Bool>(key: "graphOtherTreatments", default: true)
+    static let graphBasal = UserDefaultsValue<Bool>(key: "graphBasal", default: true)
+    static let graphBolus = UserDefaultsValue<Bool>(key: "graphBolus", default: true)
+    static let graphCarbs = UserDefaultsValue<Bool>(key: "graphCarbs", default: true)
+    static let debugLog = UserDefaultsValue<Bool>(key: "debugLog", default: false)
+    static let alwaysDownloadAllBG = UserDefaultsValue<Bool>(key: "alwaysDownloadAllBG", default: true)
+    static let bgUpdateDelay = UserDefaultsValue<Int>(key: "bgUpdateDelay", default: 10)
+    
+    
+    // Watch Calendar Settings
+    static let calendarIdentifier = UserDefaultsValue<String>(key: "calendarIdentifier", default: "")
+    static let savedEventID = UserDefaultsValue<String>(key: "savedEventID", default: "")
+    static let lastCalendarStartDate = UserDefaultsValue<Date?>(key: "lastCalendarStartDate", default: nil)
+    static let writeCalendarEvent = UserDefaultsValue<Bool>(key: "writeCalendarEvent", default: false)
+    static let watchLine1 = UserDefaultsValue<String>(key: "watchLine1", default: "%BG% %DIRECTION% %DELTA% %MINAGO%")
+    static let watchLine2 = UserDefaultsValue<String>(key: "watchLine2", default: "C:%COB% I:%IOB% B:%BASAL%")
+    static let saveImage = UserDefaultsValue<Bool>(key: "saveImage", default: false)
+    
+    // Alarm Settings
+    static let systemOutputVolume = UserDefaultsValue<Float>(key: "systemOutputVolume", default: 0.5)
+    static let fadeInTimeInterval = UserDefaultsValue<TimeInterval>(key: "fadeInTimeInterval", default: 0)
+    static let vibrate = UserDefaultsValue<Bool>(key: "vibrate", default: true)
+    static let overrideSystemOutputVolume = UserDefaultsValue<Bool>(key: "overrideSystemOutputVolume", default: true)
+    static let forcedOutputVolume = UserDefaultsValue<Float>(key: "forcedOutputVolume", default: 0.5)
+    
+    
+    // Alerts
+    
+    static let quietHourStart = UserDefaultsValue<Date?>(key: "quietHourStart", default: nil) //eventually need to adjust this to night time instead of quiet hour to clean up
+    static let quietHourEnd = UserDefaultsValue<Date?>(key: "quietHourEnd", default: nil) //eventually need to adjust this to night time instead of quiet hour to clean up
+    static let nightTime = UserDefaultsValue<Bool>(key: "nightTime", default: false)
+    
+    static let snoozedBGReadingTime = UserDefaultsValue<TimeInterval?>(key: "snoozedBGReadingTime", default: 0)
+    
+    static let alertCageInsertTime = UserDefaultsValue<TimeInterval>(key: "alertCageInsertTime", default: 0)
+    static let alertSageInsertTime = UserDefaultsValue<TimeInterval>(key: "alertSageInsertTime", default: 0)
+    
+    static let alertSnoozeAllTime = UserDefaultsValue<Date?>(key: "alertSnoozeAllTime", default: nil)
+    static let alertSnoozeAllIsSnoozed = UserDefaultsValue<Bool>(key: "alertSnoozeAllIsSnoozed", default: false)
+    
+    static let alertUrgentLowActive = UserDefaultsValue<Bool>(key: "alertUrgentLowActive", default: false)
+    static let alertUrgentLowBG = UserDefaultsValue<Float>(key: "alertUrgentLowBG", default: 55.0)
+    static let alertUrgentLowSnooze = UserDefaultsValue<Int>(key: "alertUrgentLowSnooze", default: 5)
+    static let alertUrgentLowSnoozedTime = UserDefaultsValue<Date?>(key: "alertUrgentLowSnoozedTime", default: nil)
+    static let alertUrgentLowIsSnoozed = UserDefaultsValue<Bool>(key: "alertUrgentLowIsSnoozed", default: false)
+    static let alertUrgentLowRepeat = UserDefaultsValue<String>(key: "alertUrgentLowRepeat", default: "Do not repeat")
+    static let alertUrgentLowDayTime = UserDefaultsValue<Bool>(key: "alertUrgentLowDayTime", default: false)
+    static let alertUrgentLowNightTime = UserDefaultsValue<Bool>(key: "alertUrgentLowNightTime", default: false)
+    static let alertUrgentLowSound = UserDefaultsValue<String>(key: "alertUrgentLowSound", default: "Emergency_Alarm_Siren")
+    
+    static let alertLowActive = UserDefaultsValue<Bool>(key: "alertLowActive", default: false)
+    static let alertLowBG = UserDefaultsValue<Float>(key: "alertLowBG", default: 70.0)
+    static let alertLowSnooze = UserDefaultsValue<Int>(key: "alertLowSnooze", default: 5)
+    static let alertLowSnoozedTime = UserDefaultsValue<Date?>(key: "alertLowSnoozedTime", default: nil)
+    static let alertLowIsSnoozed = UserDefaultsValue<Bool>(key: "alertLowIsSnoozed", default: false)
+    static let alertLowRepeat = UserDefaultsValue<String>(key: "alertLowRepeat", default: "Do not repeat")
+    static let alertLowDayTime = UserDefaultsValue<Bool>(key: "alertLowDayTime", default: false)
+    static let alertLowNightTime = UserDefaultsValue<Bool>(key: "alertLowNightTime", default: false)
+    static let alertLowSound = UserDefaultsValue<String>(key: "alertLowSound", default: "Indeed")
+    
+    static let alertHighActive = UserDefaultsValue<Bool>(key: "alertHighActive", default: false)
+    static let alertHighBG = UserDefaultsValue<Float>(key: "alertHighBG", default: 180.0)
+    static let alertHighPersistent = UserDefaultsValue<Int>(key: "alertHighPersistent", default: 60)
+    static let alertHighSnooze = UserDefaultsValue<Int>(key: "alertHighSnooze", default: 60)
+    static let alertHighSnoozedTime = UserDefaultsValue<Date?>(key: "alertHighSnoozedTime", default: nil)
+    static let alertHighIsSnoozed = UserDefaultsValue<Bool>(key: "alertHighIsSnoozed", default: false)
+    static let alertHighRepeat = UserDefaultsValue<String>(key: "alertHighRepeat", default: "Do not repeat")
+    static let alertHighDayTime = UserDefaultsValue<Bool>(key: "alertHighDayTime", default: false)
+    static let alertHighNightTime = UserDefaultsValue<Bool>(key: "alertHighNightTime", default: false)
+    static let alertHighSound = UserDefaultsValue<String>(key: "alertHighSound", default: "Time_Has_Come")
+    
+    static let alertUrgentHighActive = UserDefaultsValue<Bool>(key: "alertUrgentHighActive", default: false)
+    static let alertUrgentHighBG = UserDefaultsValue<Float>(key: "alertUrgentHighBG", default: 250.0)
+    static let alertUrgentHighSnooze = UserDefaultsValue<Int>(key: "alertUrgentHighSnooze", default: 30)
+    static let alertUrgentHighSnoozedTime = UserDefaultsValue<Date?>(key: "alertUrgentHighSnoozedTime", default: nil)
+    static let alertUrgentHighIsSnoozed = UserDefaultsValue<Bool>(key: "alertUrgentHighIsSnoozed", default: false)
+    static let alertUrgentHighRepeat = UserDefaultsValue<String>(key: "alertUrgentHighRepeat", default: "Do not repeat")
+    static let alertUrgentHighDayTime = UserDefaultsValue<Bool>(key: "alertUrgentHighDayTime", default: false)
+    static let alertUrgentHighNightTime = UserDefaultsValue<Bool>(key: "alertUrgentHighNightTime", default: false)
+    static let alertUrgentHighSound = UserDefaultsValue<String>(key: "alertUrgentHighSound", default: "Pager_Beeps")
+
+    
+    static let alertFastDropActive = UserDefaultsValue<Bool>(key: "alertFastDropDeltaActive", default: false)
+    static let alertFastDropSnooze = UserDefaultsValue<Int>(key: "alertFastDropDeltaSnooze", default: 10)
+    static let alertFastDropDelta = UserDefaultsValue<Float>(key: "alertFastDropDelta", default: 10.0)
+    static let alertFastDropReadings = UserDefaultsValue<Int>(key: "alertFastDropReadings", default: 3)
+    static let alertFastDropUseLimit = UserDefaultsValue<Bool>(key: "alertFastDropUseLimit", default: false)
+    static let alertFastDropBelowBG = UserDefaultsValue<Float>(key: "alertFastDropBelowBG", default: 120.0)
+    static let alertFastDropSnoozedTime = UserDefaultsValue<Date?>(key: "alertFastDropSnoozedTime", default: nil)
+    static let alertFastDropIsSnoozed = UserDefaultsValue<Bool>(key: "alertFastDropIsSnoozed", default: false)
+    static let alertFastDropRepeat = UserDefaultsValue<String>(key: "alertFastDropRepeat", default: "Do not repeat")
+    static let alertFastDropDayTime = UserDefaultsValue<Bool>(key: "alertFastDropDayTime", default: false)
+    static let alertFastDropNightTime = UserDefaultsValue<Bool>(key: "alertFastDropNightTime", default: false)
+    static let alertFastDropSound = UserDefaultsValue<String>(key: "alertFastDropSound", default: "Big_Clock_Ticking")
+    
+    static let alertFastRiseActive = UserDefaultsValue<Bool>(key: "alertFastRiseDeltaActive", default: false)
+    static let alertFastRiseSnooze = UserDefaultsValue<Int>(key: "alertFastRiseDeltaSnooze", default: 10)
+    static let alertFastRiseDelta = UserDefaultsValue<Float>(key: "alertFastRiseDelta", default: 10.0)
+    static let alertFastRiseReadings = UserDefaultsValue<Int>(key: "alertFastRiseReadings", default: 3)
+    static let alertFastRiseUseLimit = UserDefaultsValue<Bool>(key: "alertFastRiseUseLimit", default: false)
+    static let alertFastRiseAboveBG = UserDefaultsValue<Float>(key: "alertFastRiseAboveBG", default: 200.0)
+    static let alertFastRiseSnoozedTime = UserDefaultsValue<Date?>(key: "alertFastRiseSnoozedTime", default: nil)
+    static let alertFastRiseIsSnoozed = UserDefaultsValue<Bool>(key: "alertFastRiseIsSnoozed", default: false)
+    static let alertFastRiseRepeat = UserDefaultsValue<String>(key: "alertFastRiseRepeat", default: "Do not repeat")
+    static let alertFastRiseDayTime = UserDefaultsValue<Bool>(key: "alertFastRiseDayTime", default: false)
+    static let alertFastRiseNightTime = UserDefaultsValue<Bool>(key: "alertFastRiseNightTime", default: false)
+    static let alertFastRiseSound = UserDefaultsValue<String>(key: "alertFastRiseSound", default: "Cartoon_Fail_Strings_Trumpet")
+    
+    
+    static let alertMissedReadingActive = UserDefaultsValue<Bool>(key: "alertMissedReadingActive", default: false)
+    static let alertMissedReading = UserDefaultsValue<Int>(key: "alertMissedReading", default: 30)
+    static let alertMissedReadingSnooze = UserDefaultsValue<Int>(key: "alertMissedReadingSnooze", default: 30)
+    static let alertMissedReadingSnoozedTime = UserDefaultsValue<Date?>(key: "alertMissedReadingSnoozedTime", default: nil)
+    static let alertMissedReadingIsSnoozed = UserDefaultsValue<Bool>(key: "alertMissedReadingIsSnoozed", default: false)
+    static let alertMissedReadingRepeat = UserDefaultsValue<String>(key: "alertMissedReadingRepeat", default: "Do not repeat")
+    static let alertMissedReadingDayTime = UserDefaultsValue<Bool>(key: "alertMissedReadingDayTime", default: false)
+    static let alertMissedReadingNightTime = UserDefaultsValue<Bool>(key: "alertMissedReadingNightTime", default: false)
+    static let alertMissedReadingSound = UserDefaultsValue<String>(key: "alertMissedReadingSound", default: "Cartoon_Tip_Toe_Sneaky_Walk")
+    
+    
+    static let alertNotLoopingActive = UserDefaultsValue<Bool>(key: "alertNotLoopingActive", default: false)
+    static let alertNotLooping = UserDefaultsValue<Int>(key: "alertNotLooping", default: 30)
+    static let alertNotLoopingSnooze = UserDefaultsValue<Int>(key: "alertNotLoopingSnooze", default: 30)
+    static let alertNotLoopingUseLimits = UserDefaultsValue<Bool>(key: "alertNotLoopingUseLimits", default: false)
+    static let alertNotLoopingLowerLimit = UserDefaultsValue<Float>(key: "alertNotLoopingBelowBG", default: 100.0)
+    static let alertNotLoopingUpperLimit = UserDefaultsValue<Float>(key: "alertNotLoopingAboveBG", default: 160.0)
+    static let alertNotLoopingSnoozedTime = UserDefaultsValue<Date?>(key: "alertNotLoopingSnoozedTime", default: nil)
+    static let alertNotLoopingIsSnoozed = UserDefaultsValue<Bool>(key: "alertNotLoopingIsSnoozed", default: false)
+    static let alertNotLoopingRepeat = UserDefaultsValue<String>(key: "alertNotLoopingRepeat", default: "Do not repeat")
+    static let alertNotLoopingDayTime = UserDefaultsValue<Bool>(key: "alertNotLoopingDayTime", default: false)
+    static let alertNotLoopingNightTime = UserDefaultsValue<Bool>(key: "alertNotLoopingNightTime", default: false)
+    static let alertNotLoopingSound = UserDefaultsValue<String>(key: "alertNotLoopingSound", default: "Sci-Fi_Engine_Shut_Down")
+    static let alertLastLoopTime = UserDefaultsValue<TimeInterval>(key: "alertLastLoopTime", default: 0)
+    
+    static let alertMissedBolusActive = UserDefaultsValue<Bool>(key: "alertMissedBolusActive", default: false)
+    static let alertMissedBolus = UserDefaultsValue<Int>(key: "alertMissedBolus", default: 10)
+    static let alertMissedBolusSnooze = UserDefaultsValue<Int>(key: "alertMissedBolusSnooze", default: 10)
+    static let alertMissedBolusPrebolus = UserDefaultsValue<Int>(key: "alertMissedBolusPrebolus", default: 20)
+    static let alertMissedBolusIgnoreBolus = UserDefaultsValue<Double>(key: "alertMissedBolusIgnoreBolus", default: 0.5)
+    static let alertMissedBolusLowGrams = UserDefaultsValue<Int>(key: "alertMissedBolusLowGrams", default: 10)
+    static let alertMissedBolusLowGramsBG = UserDefaultsValue<Float>(key: "alertMissedBolusLowGramsBG", default: 70.0)
+    static let alertMissedBolusSnoozedTime = UserDefaultsValue<Date?>(key: "alertMissedBolusSnoozedTime", default: nil)
+    static let alertMissedBolusIsSnoozed = UserDefaultsValue<Bool>(key: "alertMissedBolusIsSnoozed", default: false)
+    static let alertMissedBolusQuiet = UserDefaultsValue<Bool>(key: "alertMissedBolusQuiet", default: false)
+    static let alertMissedBolusRepeat = UserDefaultsValue<String>(key: "alertMissedBolusRepeat", default: "Do not repeat")
+    static let alertMissedBolusDayTime = UserDefaultsValue<Bool>(key: "alertMissedBolusDayTime", default: false)
+    static let alertMissedBolusNightTime = UserDefaultsValue<Bool>(key: "alertMissedBolusNightTime", default: false)
+    static let alertMissedBolusSound = UserDefaultsValue<String>(key: "alertMissedBolusSound", default: "Dhol_Shuffleloop")
+    
+    static let alertSAGEActive = UserDefaultsValue<Bool>(key: "alertSAGEActive", default: false)
+    static let alertSAGE = UserDefaultsValue<Int>(key: "alertSAGE", default: 8) //Hours
+    static let alertSAGEQuiet = UserDefaultsValue<Bool>(key: "alertSAGEQuiet", default: false)
+    static let alertSAGERepeat = UserDefaultsValue<String>(key: "alertSAGERepeat", default: "Do not repeat")
+    static let alertSAGEDayTime = UserDefaultsValue<Bool>(key: "alertSAGEDayTime", default: false)
+    static let alertSAGENightTime = UserDefaultsValue<Bool>(key: "alertSAGENightTime", default: false)
+    static let alertSAGESnooze = UserDefaultsValue<Int>(key: "alertSAGESnooze", default: 2) //Hours
+    static let alertSAGESnoozedTime = UserDefaultsValue<Date?>(key: "alertSAGESnoozedTime", default: nil)
+    static let alertSAGEIsSnoozed = UserDefaultsValue<Bool>(key: "alertSAGEIsSnoozed", default: false)
+    static let alertSAGESound = UserDefaultsValue<String>(key: "alertSAGESound", default: "Wake_Up_Will_You")
+    
+    static let alertCAGEActive = UserDefaultsValue<Bool>(key: "alertCAGEActive", default: false)
+    static let alertCAGE = UserDefaultsValue<Int>(key: "alertCAGE", default: 4) //Hours
+    static let alertCAGEQuiet = UserDefaultsValue<Bool>(key: "alertCAGEQuiet", default: false)
+    static let alertCAGERepeat = UserDefaultsValue<String>(key: "alertCAGERepeat", default: "Do not repeat")
+    static let alertCAGEDayTime = UserDefaultsValue<Bool>(key: "alertCAGEDayTime", default: false)
+    static let alertCAGENightTime = UserDefaultsValue<Bool>(key: "alertCAGENightTime", default: false)
+    static let alertCAGESnooze = UserDefaultsValue<Int>(key: "alertCAGESnooze", default: 2) //Hours
+    static let alertCAGESnoozedTime = UserDefaultsValue<Date?>(key: "alertCAGESnoozedTime", default: nil)
+    static let alertCAGEIsSnoozed = UserDefaultsValue<Bool>(key: "alertCAGEIsSnoozed", default: false)
+    static let alertCAGESound = UserDefaultsValue<String>(key: "alertCAGESound", default: "Wake_Up_Will_You")
+    
+    static let alertAppInactive = UserDefaultsValue<Bool>(key: "alertAppInactive", default: false)
+    
+    static let alertTemporaryActive = UserDefaultsValue<Bool>(key: "alertTemporaryActive", default: false)
+    static let alertTemporaryBelow = UserDefaultsValue<Bool>(key: "alertTemporaryBelow", default: true)
+    static let alertTemporaryBG = UserDefaultsValue<Float>(key: "alertTemporaryBG", default: 90.0)
+    static let alertTemporaryBGRepeat = UserDefaultsValue<Bool>(key: "alertTemporaryBGRepeat", default: true)
+    static let alertTemporarySound = UserDefaultsValue<String>(key: "alertTemporarySound", default: "Indeed")
+    
+    static let alertOverrideStart = UserDefaultsValue<Bool>(key: "alertOverrideStart", default: false)
+    static let alertOverrideStartQuiet = UserDefaultsValue<Bool>(key: "alertOverrideStartQuiet", default: false)
+    static let alertOverrideStartRepeat = UserDefaultsValue<String>(key: "alertOverrideStartRepeat", default: "Do not repeat")
+    static let alertOverrideStartDayTime = UserDefaultsValue<Bool>(key: "alertOverrideStartDayTime", default: false)
+    static let alertOverrideStartNightTime = UserDefaultsValue<Bool>(key: "alertOverrideStartNightTime", default: false)
+    static let alertOverrideStartSound = UserDefaultsValue<String>(key: "alertOverrideStartSound", default: "Ending_Reached")
+    static let alertOverrideStartSnoozedTime = UserDefaultsValue<Date?>(key: "alertOverrideStartSnoozedTime", default: nil)
+    static let alertOverrideStartIsSnoozed = UserDefaultsValue<Bool>(key: "alertOverrideStartIsSnoozed", default: false)
+    
+    static let alertOverrideEnd = UserDefaultsValue<Bool>(key: "alertOverrideEnd", default: false)
+    static let alertOverrideEndQuiet = UserDefaultsValue<Bool>(key: "alertOverrideEndQuiet", default: false)
+    static let alertOverrideEndRepeat = UserDefaultsValue<String>(key: "alertOverrideEndRepeat", default: "Do not repeat")
+    static let alertOverrideEndDayTime = UserDefaultsValue<Bool>(key: "alertOverrideEndDayTime", default: false)
+    static let alertOverrideEndNightTime = UserDefaultsValue<Bool>(key: "alertOverrideEndNightTime", default: false)
+    static let alertOverrideEndSound = UserDefaultsValue<String>(key: "alertOverrideEndSound", default: "Alert_Tone_Busy")
+    static let alertOverrideEndSnoozedTime = UserDefaultsValue<Date?>(key: "alertOverrideEndSnoozedTime", default: nil)
+    static let alertOverrideEndIsSnoozed = UserDefaultsValue<Bool>(key: "alertOverrideEndIsSnoozed", default: false)
+    
+    static let alertPump = UserDefaultsValue<Bool>(key: "alertPump", default: false)
+    static let alertPumpAt = UserDefaultsValue<Int>(key: "alertPumpAt", default: 10) //Units
+    static let alertPumpQuiet = UserDefaultsValue<Bool>(key: "alertPumpQuiet", default: false)
+    static let alertPumpRepeat = UserDefaultsValue<String>(key: "alertPumpRepeat", default: "Do not repeat")
+    static let alertPumpDayTime = UserDefaultsValue<Bool>(key: "alertPumpDayTime", default: false)
+    static let alertPumpNightTime = UserDefaultsValue<Bool>(key: "alertPumpNightTime", default: false)
+    static let alertPumpSound = UserDefaultsValue<String>(key: "alertPumpSound", default: "Marimba_Descend")
+    static let alertPumpSnoozeHours = UserDefaultsValue<Int>(key: "alertPumpSnoozeHours", default: 5) //Hours
+    static let alertPumpIsSnoozed = UserDefaultsValue<Bool>(key: "alertPumpIsSnoozed", default: false)
+    static let alertPumpSnoozedTime = UserDefaultsValue<Date?>(key: "alertPumpSnoozedTime", default: nil)
+    
+}


### PR DESCRIPTION
Added an option to repeat alerts when quiet hours are on.  Forces all critical alerts to repeat regardless of the setting in the individual alert.  Idea is that you can have alerts not repeat during the day but at night when sleeping, the alerts do repeat to help wake someone up.  Alerts defined as critical are Urgent Low, Low, High, Urgent High, No Readings, No Looping, Fast Drop, and Fast Rise.  Note that the alerts will **not** fire (and therefore not repeat) if the alert is not active. This change only affects active alerts.