### PR TITLE
Show more than 1 day of data in the chart

### DIFF
--- a/LoopFollow/Controllers/AppStateController.swift
+++ b/LoopFollow/Controllers/AppStateController.swift
@@ -28,6 +28,8 @@ enum ChartSettingsChangeEnum: Int {
   case lowLineChanged = 512
   case highLineChanged = 1024
   case smallGraphHeight = 2048
+  case showDIALinesChanged = 4096
+  case showMidnightLinesChanged = 8192
 }
 
 // General Settings Flags

--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -305,6 +305,7 @@ extension MainViewController {
         
         // Add Now Line
         createNowAndDIALines()
+        createMidnightLines()
         startGraphNowTimer()
         
         // Setup the main graph overall details
@@ -364,6 +365,24 @@ extension MainViewController {
                 ul.lineDashLengths = [CGFloat(dash), CGFloat(space)]
                 ul.lineWidth = 1
                 BGChart.xAxis.addLimitLine(ul)
+            }
+        }
+    }
+    
+    func createMidnightLines() {
+        // Draw a line at midnight: useful when showing multiple days of data
+        if UserDefaultsRepository.showMidnightLines.value {
+            var midnightTimeInterval = dateTimeUtils.getTimeIntervalMidnightToday()
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            let graphStart = dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours)
+            while midnightTimeInterval > graphStart {
+                let ul = ChartLimitLine()
+                ul.limit = Double(midnightTimeInterval)
+                ul.lineColor = NSUIColor.systemIndigo.withAlphaComponent(0.5)
+                ul.lineDashLengths = [CGFloat(2), CGFloat(5)]
+                ul.lineWidth = 1
+                BGChart.xAxis.addLimitLine(ul)
+                midnightTimeInterval = midnightTimeInterval.advanced(by: -24*60*60)
             }
         }
     }
@@ -641,8 +660,9 @@ extension MainViewController {
                 dateTimeStamp = dateTimeStamp - 150
             }
             
-            // skip if > 24 hours old
-            if dateTimeStamp < dateTimeUtils.getTimeInterval24HoursAgo() { continue }
+            // skip if outside of visible area
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            if dateTimeStamp < dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) { continue }
   
             let dot = ChartDataEntry(x: Double(dateTimeStamp), y: Double(bolusData[i].sgv), data: formatter.string(from: NSNumber(value: bolusData[i].value)))
             mainChart.addEntry(dot)
@@ -717,8 +737,9 @@ extension MainViewController {
                 colors.append(NSUIColor.systemOrange.withAlphaComponent(CGFloat(thisAlpha)))
             }
             
-            // skip if > 24 hours old
-            if dateTimeStamp < dateTimeUtils.getTimeInterval24HoursAgo() { continue }
+            // skip if outside of visible area
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            if dateTimeStamp < dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) { continue }
             
             if carbShift {
                 dateTimeStamp = dateTimeStamp - 250
@@ -773,8 +794,9 @@ extension MainViewController {
             formatter.maximumFractionDigits = 2
             formatter.minimumIntegerDigits = 1
             
-            // skip if > 24 hours old
-            if bgCheckData[i].date < dateTimeUtils.getTimeInterval24HoursAgo() { continue }
+            // skip if outside of visible area
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            if bgCheckData[i].date < dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) { continue }
             
             let value = ChartDataEntry(x: Double(bgCheckData[i].date), y: Double(bgCheckData[i].sgv), data: formatPillText(line1: bgUnits.toDisplayUnits(String(bgCheckData[i].sgv)), time: bgCheckData[i].date))
             BGChart.data?.dataSets[dataIndex].addEntry(value)
@@ -800,8 +822,9 @@ extension MainViewController {
         BGChartFull.lineData?.dataSets[dataIndex].clear()
         let thisData = suspendGraphData
         for i in 0..<thisData.count{
-            // skip if > 24 hours old
-            if thisData[i].date < dateTimeUtils.getTimeInterval24HoursAgo() { continue }
+            // skip if outside of visible area
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            if thisData[i].date < dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) { continue }
             
             let value = ChartDataEntry(x: Double(thisData[i].date), y: Double(thisData[i].sgv), data: formatPillText(line1: "Suspend Pump", time: thisData[i].date))
             BGChart.data?.dataSets[dataIndex].addEntry(value)
@@ -826,8 +849,9 @@ extension MainViewController {
         BGChartFull.lineData?.dataSets[dataIndex].clear()
         let thisData = resumeGraphData
         for i in 0..<thisData.count{
-            // skip if > 24 hours old
-            if thisData[i].date < dateTimeUtils.getTimeInterval24HoursAgo() { continue }
+            // skip if outside of visible area
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            if thisData[i].date < dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) { continue }
             
             let value = ChartDataEntry(x: Double(thisData[i].date), y: Double(thisData[i].sgv), data: formatPillText(line1: "Resume Pump", time: thisData[i].date))
             BGChart.data?.dataSets[dataIndex].addEntry(value)
@@ -852,8 +876,9 @@ extension MainViewController {
         BGChartFull.lineData?.dataSets[dataIndex].clear()
         let thisData = sensorStartGraphData
         for i in 0..<thisData.count{
-            // skip if > 24 hours old
-            if thisData[i].date < dateTimeUtils.getTimeInterval24HoursAgo() { continue }
+            // skip if outside of visible area
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            if thisData[i].date < dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) { continue }
             
             let value = ChartDataEntry(x: Double(thisData[i].date), y: Double(thisData[i].sgv), data: formatPillText(line1: "Start Sensor", time: thisData[i].date))
             BGChart.data?.dataSets[dataIndex].addEntry(value)
@@ -879,8 +904,9 @@ extension MainViewController {
         let thisData = noteGraphData
         for i in 0..<thisData.count{
             
-            // skip if > 24 hours old
-            if thisData[i].date < dateTimeUtils.getTimeInterval24HoursAgo() { continue }
+            // skip if outside of visible area
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            if thisData[i].date < dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours) { continue }
             
             let value = ChartDataEntry(x: Double(thisData[i].date), y: Double(thisData[i].sgv), data: formatPillText(line1: thisData[i].note, time: thisData[i].date))
             BGChart.data?.dataSets[dataIndex].addEntry(value)

--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -303,9 +303,8 @@ extension MainViewController {
         ul.lineColor = NSUIColor.systemYellow.withAlphaComponent(0.5)
         BGChart.rightAxis.addLimitLine(ul)
         
-        // Add Now Line
-        createNowAndDIALines()
-        createMidnightLines()
+        // Add vertical lines as configured
+        createVerticalLines()
         startGraphNowTimer()
         
         // Setup the main graph overall details
@@ -346,8 +345,14 @@ extension MainViewController {
         
     }
     
-    func createNowAndDIALines() {
+    func createVerticalLines() {
         BGChart.xAxis.removeAllLimitLines()
+        BGChartFull.xAxis.removeAllLimitLines()
+        createNowAndDIALines()
+        createMidnightLines()
+    }
+    
+    func createNowAndDIALines() {
         let ul = ChartLimitLine()
         ul.limit = Double(dateTimeUtils.getNowTimeIntervalUTC())
         ul.lineColor = NSUIColor.systemGray.withAlphaComponent(0.5)
@@ -376,12 +381,22 @@ extension MainViewController {
             let graphHours = 24 * UserDefaultsRepository.downloadDays.value
             let graphStart = dateTimeUtils.getTimeIntervalNHoursAgo(N: graphHours)
             while midnightTimeInterval > graphStart {
+                // Large chart
                 let ul = ChartLimitLine()
                 ul.limit = Double(midnightTimeInterval)
-                ul.lineColor = NSUIColor.systemIndigo.withAlphaComponent(0.5)
+                ul.lineColor = NSUIColor.systemTeal.withAlphaComponent(0.5)
                 ul.lineDashLengths = [CGFloat(2), CGFloat(5)]
                 ul.lineWidth = 1
                 BGChart.xAxis.addLimitLine(ul)
+
+                // Small chart
+                let sl = ChartLimitLine()
+                sl.limit = Double(midnightTimeInterval)
+                sl.lineColor = NSUIColor.systemTeal
+                sl.lineDashLengths = [CGFloat(2), CGFloat(2)]
+                sl.lineWidth = 1
+                BGChartFull.xAxis.addLimitLine(sl)
+                
                 midnightTimeInterval = midnightTimeInterval.advanced(by: -24*60*60)
             }
         }
@@ -425,9 +440,7 @@ extension MainViewController {
         BGChart.rightAxis.addLimitLine(ul)
         
         // Re-create vertical markers in case their settings changed
-        BGChart.xAxis.removeAllLimitLines()
-        createNowAndDIALines()
-        createMidnightLines()
+        createVerticalLines()
     
         BGChart.data?.dataSets[dataIndex].notifyDataSetChanged()
         BGChart.data?.notifyDataChanged()
@@ -1146,7 +1159,9 @@ extension MainViewController {
         BGChartFull.rightAxis.axisMinimum = 0.0
         BGChartFull.rightAxis.axisMaximum = Double(maxBG)
                                                
-        BGChartFull.xAxis.enabled = false
+        BGChartFull.xAxis.drawLabelsEnabled = false
+        BGChartFull.xAxis.drawGridLinesEnabled = false
+        BGChartFull.xAxis.drawAxisLineEnabled = false
         BGChartFull.legend.enabled = false
         BGChartFull.scaleYEnabled = false
         BGChartFull.scaleXEnabled = false

--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -423,6 +423,11 @@ extension MainViewController {
         ul.limit = Double(UserDefaultsRepository.highLine.value)
         ul.lineColor = NSUIColor.systemYellow.withAlphaComponent(0.5)
         BGChart.rightAxis.addLimitLine(ul)
+        
+        // Re-create vertical markers in case their settings changed
+        BGChart.xAxis.removeAllLimitLines()
+        createNowAndDIALines()
+        createMidnightLines()
     
         BGChart.data?.dataSets[dataIndex].notifyDataSetChanged()
         BGChart.data?.notifyDataChanged()

--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -199,7 +199,7 @@ extension MainViewController {
                         }
                         nsData.removeFirst(itemsToRemove)
                         nsData = dexData + nsData
-                        sourceName = "Dexcom + Nightscout"
+                        sourceName = "Dexcom"
                     }
                     
                     // trigger the processor for the data after downloading.

--- a/LoopFollow/Controllers/StatsView.swift
+++ b/LoopFollow/Controllers/StatsView.swift
@@ -16,7 +16,19 @@ extension MainViewController {
     func updateStats()
     {
         if bgData.count > 0 {
-           let stats = StatsData(bgData: bgData)
+            var lastDayOfData = bgData
+            let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+            // If we loaded more than 1 day of data, only use the last day for the stats
+            if graphHours > 24 {
+                let oneDayAgo = dateTimeUtils.getTimeIntervalNHoursAgo(N: 24)
+                var startIndex = 0
+                while startIndex < bgData.count && bgData[startIndex].date < oneDayAgo {
+                    startIndex += 1
+                }
+                lastDayOfData = Array(bgData.dropFirst(startIndex))
+            }
+            
+            let stats = StatsData(bgData: lastDayOfData)
             
             statsLowPercent.text = String(format:"%.1f%", stats.percentLow) + "%"
             statsInRangePercent.text = String(format:"%.1f%", stats.percentRange) + "%"

--- a/LoopFollow/Controllers/Timers.swift
+++ b/LoopFollow/Controllers/Timers.swift
@@ -87,8 +87,7 @@ extension MainViewController {
     }
     
     @objc func graphNowTimerDidEnd(_ timer:Timer) {
-        createNowAndDIALines()
-        createMidnightLines()
+        createVerticalLines()
     }
     
     // Runs a 60 second timer when an alarm is snoozed

--- a/LoopFollow/Controllers/Timers.swift
+++ b/LoopFollow/Controllers/Timers.swift
@@ -88,6 +88,7 @@ extension MainViewController {
     
     @objc func graphNowTimerDidEnd(_ timer:Timer) {
         createNowAndDIALines()
+        createMidnightLines()
     }
     
     // Runs a 60 second timer when an alarm is snoozed

--- a/LoopFollow/ViewControllers/AdvancedSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/AdvancedSettingsViewController.swift
@@ -90,21 +90,6 @@ class AdvancedSettingsViewController: FormViewController {
                     guard let value = row.value else { return }
                     UserDefaultsRepository.bgUpdateDelay.value = Int(value)
             }
-            <<< StepperRow("downloadDays") { row in
-                // NS supports 4 days, Dexcom Share only 1 day
-                row.title = "Show Days Back"
-                row.cell.stepper.stepValue = 1
-                row.cell.stepper.minimumValue = 1
-                row.cell.stepper.maximumValue = 4
-                row.value = Double(UserDefaultsRepository.downloadDays.value)
-                row.displayValueFor = { value in
-                        guard let value = value else { return nil }
-                        return "\(Int(value))"
-                    }
-            }.onChange { [weak self] row in
-                    guard let value = row.value else { return }
-                    UserDefaultsRepository.downloadDays.value = Int(value)
-            }
             <<< SwitchRow("alwaysDownloadAllBG"){ row in
                 row.title = "Allways Download All BG Values"
                 row.value = UserDefaultsRepository.alwaysDownloadAllBG.value

--- a/LoopFollow/ViewControllers/AdvancedSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/AdvancedSettingsViewController.swift
@@ -90,6 +90,21 @@ class AdvancedSettingsViewController: FormViewController {
                     guard let value = row.value else { return }
                     UserDefaultsRepository.bgUpdateDelay.value = Int(value)
             }
+            <<< StepperRow("downloadDays") { row in
+                // NS supports 4 days, Dexcom Share only 1 day
+                row.title = "Show Days Back (NS only)"
+                row.cell.stepper.stepValue = 1
+                row.cell.stepper.minimumValue = 1
+                row.cell.stepper.maximumValue = 4
+                row.value = Double(UserDefaultsRepository.downloadDays.value)
+                row.displayValueFor = { value in
+                        guard let value = value else { return nil }
+                        return "\(Int(value))"
+                    }
+            }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.downloadDays.value = Int(value)
+            }
             <<< SwitchRow("alwaysDownloadAllBG"){ row in
                 row.title = "Allways Download All BG Values"
                 row.value = UserDefaultsRepository.alwaysDownloadAllBG.value

--- a/LoopFollow/ViewControllers/AdvancedSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/AdvancedSettingsViewController.swift
@@ -92,7 +92,7 @@ class AdvancedSettingsViewController: FormViewController {
             }
             <<< StepperRow("downloadDays") { row in
                 // NS supports 4 days, Dexcom Share only 1 day
-                row.title = "Show Days Back (NS only)"
+                row.title = "Show Days Back"
                 row.cell.stepper.stepValue = 1
                 row.cell.stepper.minimumValue = 1
                 row.cell.stepper.maximumValue = 4

--- a/LoopFollow/ViewControllers/GraphSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/GraphSettingsViewController.swift
@@ -117,6 +117,14 @@ class GraphSettingsViewController: FormViewController {
                         UserDefaultsRepository.showDIALines.value = value
                         
             }
+            <<< SwitchRow("showMidnightMarkers"){ row in
+                row.title = "Show Midnight Lines"
+                row.value = UserDefaultsRepository.showMidnightLines.value
+            }.onChange { [weak self] row in
+                        guard let value = row.value else { return }
+                        UserDefaultsRepository.showMidnightLines.value = value
+                        
+            }
             <<< SwitchRow("smallGraphTreatments"){ row in
                 row.title = "Treatments on Small Graph"
                 row.value = UserDefaultsRepository.smallGraphTreatments.value

--- a/LoopFollow/ViewControllers/GraphSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/GraphSettingsViewController.swift
@@ -117,14 +117,6 @@ class GraphSettingsViewController: FormViewController {
                         UserDefaultsRepository.showDIALines.value = value
                         
             }
-            <<< SwitchRow("showMidnightMarkers"){ row in
-                row.title = "Show Midnight Lines"
-                row.value = UserDefaultsRepository.showMidnightLines.value
-            }.onChange { [weak self] row in
-                        guard let value = row.value else { return }
-                        UserDefaultsRepository.showMidnightLines.value = value
-                        
-            }
             <<< SwitchRow("smallGraphTreatments"){ row in
                 row.title = "Treatments on Small Graph"
                 row.value = UserDefaultsRepository.smallGraphTreatments.value
@@ -235,7 +227,30 @@ class GraphSettingsViewController: FormViewController {
                appState.chartSettingsChanges |= ChartSettingsChangeEnum.highLineChanged.rawValue
              }
         }
-       
+        <<< StepperRow("downloadDays") { row in
+            // NS supports up to 4 days
+            row.title = "Show Days Back"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 1
+            row.cell.stepper.maximumValue = 4
+            row.value = Double(UserDefaultsRepository.downloadDays.value)
+            row.displayValueFor = { value in
+                    guard let value = value else { return nil }
+                    return "\(Int(value))"
+                }
+        }.onChange { [weak self] row in
+                guard let value = row.value else { return }
+                UserDefaultsRepository.downloadDays.value = Int(value)
+        }
+        <<< SwitchRow("showMidnightMarkers"){ row in
+            row.title = "Show Midnight Lines"
+            row.value = UserDefaultsRepository.showMidnightLines.value
+        }.onChange { [weak self] row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.showMidnightLines.value = value
+                    
+        }
+
             
        +++ ButtonRow() {
           $0.title = "DONE"

--- a/LoopFollow/ViewControllers/GraphSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/GraphSettingsViewController.swift
@@ -116,6 +116,11 @@ class GraphSettingsViewController: FormViewController {
                         guard let value = row.value else { return }
                         UserDefaultsRepository.showDIALines.value = value
                         
+                // tell main screen that graph needs updating
+                if let appState = self!.appStateController {
+                   appState.chartSettingsChanged = true
+                   appState.chartSettingsChanges |= ChartSettingsChangeEnum.showDIALinesChanged.rawValue
+                }
             }
             <<< SwitchRow("smallGraphTreatments"){ row in
                 row.title = "Treatments on Small Graph"
@@ -249,6 +254,11 @@ class GraphSettingsViewController: FormViewController {
                     guard let value = row.value else { return }
                     UserDefaultsRepository.showMidnightLines.value = value
                     
+            // tell main screen that graph needs updating
+            if let appState = self!.appStateController {
+               appState.chartSettingsChanged = true
+               appState.chartSettingsChanges |= ChartSettingsChangeEnum.showMidnightLinesChanged.rawValue
+            }
         }
 
             

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -60,7 +60,6 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
     var currentOverride = 1.0
     
     // Vars for NS Pull
-    var graphHours:Int=24
     var mmol = false as Bool
     var urlUser = UserDefaultsRepository.url.value as String
     var token = UserDefaultsRepository.token.value as String

--- a/LoopFollow/helpers/DataStructs.swift
+++ b/LoopFollow/helpers/DataStructs.swift
@@ -17,7 +17,7 @@ class DataStructs {
     }
     
     //NS Basal Profile  Struct
-    struct basal2DayProfile: Codable {
+    struct basalProfileSegment: Codable {
         var basalRate: Double
         var startDate: TimeInterval
         var endDate: TimeInterval

--- a/LoopFollow/helpers/DateTime.swift
+++ b/LoopFollow/helpers/DateTime.swift
@@ -39,10 +39,10 @@ class dateTimeUtils {
         return midnightTimeInterval
     }
     
-    static func getTimeInterval24HoursAgo() -> TimeInterval {
+    static func getTimeIntervalNHoursAgo(N: Int) -> TimeInterval {
         let today = Date()
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
-        return yesterday.timeIntervalSince1970
+        let nHoursAgo = Calendar.current.date(byAdding: .hour, value: -N, to: today)!
+        return nHoursAgo.timeIntervalSince1970
     }
     
     static func getNowTimeIntervalUTC() -> TimeInterval {
@@ -57,15 +57,15 @@ class dateTimeUtils {
         return utcTime
     }
     
-    static func nowMinus24HoursTimeInterval() -> String {
+    static func nowMinusNHoursTimeInterval(N: Int) -> String {
         let today = Date()
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)!
+        let nHoursAgo = Calendar.current.date(byAdding: .hour, value: -N, to: today)!
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         dateFormatter.locale = Locale(identifier: "en_US")
         dateFormatter.timeZone = TimeZone.init(secondsFromGMT: 0)
-        let yesterdayString = dateFormatter.string(from: yesterday)
-        return yesterdayString
+        let nHoursAgoString = dateFormatter.string(from: nHoursAgo)
+        return nHoursAgoString
     }
     
     static func nowMinus10DaysTimeInterval() -> String {

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -55,6 +55,7 @@ class UserDefaultsRepository {
     static let minBasalScale = UserDefaultsValue<Double>(key: "minBasalScale", default: 5.0)
     static let minBGScale = UserDefaultsValue<Float>(key: "minBGScale", default: 250.0)
     static let showDIALines = UserDefaultsValue<Bool>(key: "showDIAMarkers", default: true)
+    static let showMidnightLines = UserDefaultsValue<Bool>(key: "showMidnightMarkers", default: false)
     static let lowLine = UserDefaultsValue<Float>(key: "lowLine", default: 70.0)
     static let highLine = UserDefaultsValue<Float>(key: "highLine", default: 180.0)
     static let smallGraphHeight = UserDefaultsValue<Int>(key: "smallGraphHeight", default: 40)
@@ -91,7 +92,8 @@ class UserDefaultsRepository {
     static let debugLog = UserDefaultsValue<Bool>(key: "debugLog", default: false)
     static let alwaysDownloadAllBG = UserDefaultsValue<Bool>(key: "alwaysDownloadAllBG", default: true)
     static let bgUpdateDelay = UserDefaultsValue<Int>(key: "bgUpdateDelay", default: 10)
-    
+    static let downloadDays = UserDefaultsValue<Int>(key: "downloadDays", default: 1)
+
     
     // Watch Calendar Settings
     static let calendarIdentifier = UserDefaultsValue<String>(key: "calendarIdentifier", default: "")

--- a/Pods/ShareClient/ShareClient/ShareClient.swift
+++ b/Pods/ShareClient/ShareClient/ShareClient.swift
@@ -163,9 +163,12 @@ public class ShareClient {
                 return callback(.fetchError, nil)
             }
 
+            // Dexcom Share only returns up to 24 hrs of data today
+            // Requesting more just in case this changes in the future
+            let minutes = max(1440, n * 5)
             components.queryItems = [
                 URLQueryItem(name: "sessionId", value: self.token),
-                URLQueryItem(name: "minutes", value: String(1440)),
+                URLQueryItem(name: "minutes", value: String(minutes)),
                 URLQueryItem(name: "maxCount", value: String(n))
             ]
 


### PR DESCRIPTION
Adding an ability to show more than 1 day of data in the chart.

Nightscout API by default supports up to 4 days of history. If both Dexcom share and Nightscout are configured, first 24 hrs are loaded from Dexcom and the remainder from Nightscout.

Also adding a setting to show vertical lines at midnight: convenient when looking at multiple days of data.