### PR TITLE
remove duplicate svg-readings

### DIFF
--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -115,20 +115,23 @@ extension MainViewController {
             self.startBGTimer(time: 10)
             return
         }
-        let graphHours = 24 * UserDefaultsRepository.downloadDays.value
-        // Set the count= in the url either to pull day(s) of data or only the last record
-        var points = "1"
-        if !onlyPullLastRecord {
-            points = String(graphHours * 12 + 1)
-        }
         
         // URL processor
         var urlBGDataPath: String = UserDefaultsRepository.url.value + "/api/v1/entries/sgv.json?"
-        if token == "" {
-            urlBGDataPath = urlBGDataPath + "count=" + points
+        
+        if onlyPullLastRecord {
+            urlBGDataPath = urlBGDataPath + "count=1"
         } else {
-            urlBGDataPath = urlBGDataPath + "token=" + token + "&count=" + points
+            //Fetch entries for the time period of "downloadDays"
+            let utcISODateFormatter = ISO8601DateFormatter()
+            let date = Calendar.current.date(byAdding: .day, value: -1 * UserDefaultsRepository.downloadDays.value, to: Date())!
+            urlBGDataPath = urlBGDataPath + "count=1000&find[dateString][$gte]=" + utcISODateFormatter.string(from: date)
         }
+        
+        if !token.isEmpty {
+            urlBGDataPath = urlBGDataPath + "&token=" + token
+        }
+        
         guard let urlBGData = URL(string: urlBGDataPath) else {
             // if we have Dex data, use it
             if !dexData.isEmpty {
@@ -196,22 +199,39 @@ extension MainViewController {
                         nsData[i].date /= 1000
                         nsData[i].date.round(FloatingPointRoundingRule.toNearestOrEven)
                     }
+                    print(nsData.count)
+                    
+                    //Avoid duplicate entries messing up the graph, only use one reading per 5 minutes.
+                    let graphHours = 24 * UserDefaultsRepository.downloadDays.value
+                    let points = graphHours * 12 + 1
+                    var nsData2 = [ShareGlucoseData]()
+                    let timestamp = Date().timeIntervalSince1970
+                    for i in 0..<points {
+                        //Starting with "now" and then step 5 minutes back in time
+                        let target = timestamp - Double(i) * 60 * 5
+                        //Find the reading closest to the target, but not too far away
+                        let closest = nsData.filter{ abs($0.date - target) < 3 * 60 }.min { abs($0.date - target) < abs($1.date - target) }
+                        //If a reading is found, add it to the new array
+                        if let item = closest {
+                            nsData2.append(item)
+                        }
+                    }
+                    print(nsData2.count)
                     
                     // merge NS and Dex data if needed; use recent Dex data and older NS data
                     var sourceName = "Nightscout"
                     if !dexData.isEmpty {
                         let oldestDexDate = dexData[dexData.count - 1].date
                         var itemsToRemove = 0
-                        while itemsToRemove < nsData.count && nsData[itemsToRemove].date >= oldestDexDate {
+                        while itemsToRemove < nsData2.count && nsData2[itemsToRemove].date >= oldestDexDate {
                             itemsToRemove += 1
                         }
-                        nsData.removeFirst(itemsToRemove)
-                        nsData = dexData + nsData
+                        nsData2.removeFirst(itemsToRemove)
+                        nsData2 = dexData + nsData2
                         sourceName = "Dexcom"
                     }
-                    
                     // trigger the processor for the data after downloading.
-                    self.ProcessDexBGData(data: nsData, onlyPullLastRecord: onlyPullLastRecord, sourceName: sourceName)
+                    self.ProcessDexBGData(data: nsData2, onlyPullLastRecord: onlyPullLastRecord, sourceName: sourceName)
                     
                 }
             } else {


### PR DESCRIPTION
Since Loop 3 we get duplicate svg-records in nightscout using Dexcom G6, and "upload readings".

Loop 3 upload both:
device":"loop://Dexcom/G6/21.0"
and
device":"loop://iPhone"

This results in a graph that covers only a part of the day since only 298 entries are downloaded.
For example:
![image](https://user-images.githubusercontent.com/12718238/213907820-74855d95-cdfd-40ff-87b6-3f511934b9fa.png)

Even if this is a bug in Loop, I think LoopFollow should tolerate duplicate readings, this pull request is a suggestion of how it could be handled.

Solution walkthrough:
Entries are downloaded based on time (count=1000&find[dateString][$gte]=....) instead of a fixed number.
A new array is created, and for each 5-minute reading that is desired the closest reading for that time is copied over from the nightscout array to the new one. (closest = nsData.filter{ abs($0.date - target) < 3 * 60 }.min { abs($0.date - target) < abs($1.date - target) })

