### PR TITLE
Remove App Groups from LoopFollow target, and app group capabilities from Fastfile

### DIFF
--- a/LoopFollow/Loop Follow.entitlements
+++ b/LoopFollow/Loop Follow.entitlements
@@ -4,10 +4,6 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.$(unique_id).LoopFollow</string>
-	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.personal-information.calendars</key>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -132,8 +132,6 @@ platform :ios do
     end
 
     configure_bundle_id("LoopFollow", "com.#{TEAMID}.LoopFollow", [
-      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
-      Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT
     ])
     
   end


### PR DESCRIPTION
App Groups are not used in this project, and can be removed for a simplified Fastlane cloud build setup.