### PR TITLE
Home Screen Quick Action for Speak BG

### DIFF
--- a/LoopFollow/Application/SceneDelegate.swift
+++ b/LoopFollow/Application/SceneDelegate.swift
@@ -7,10 +7,12 @@
 //
 
 import UIKit
+import AVFoundation
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    let synthesizer = AVSpeechSynthesizer()
 
     let appStateController = AppStateController()
     
@@ -49,6 +51,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                vc.appStateController = appStateController
             }
          }
+
+        // Register the SceneDelegate as an observer for the "toggleSpeakBG" notification, which will be triggered when the user toggles the "Speak BG" feature in General Settings. This helps ensure that the Quick Action is updated according to the current setting.
+        NotificationCenter.default.addObserver(self, selector: #selector(handleToggleSpeakBGEvent), name: NSNotification.Name("toggleSpeakBG"), object: nil)
+        updateQuickActions()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -56,6 +62,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name("toggleSpeakBG"), object: nil)
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
@@ -82,6 +90,41 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 
+    // Update the Home Screen Quick Action for toggling the "Speak BG" feature based on the current setting in UserDefaultsRepository. This function uses UIApplicationShortcutItem to create a 3D touch action for controlling the feature.
+    func updateQuickActions() {
+        let iconName = UserDefaultsRepository.speakBG.value ? "pause.circle.fill" : "play.circle.fill"
+        let iconTemplate = UIApplicationShortcutIcon(systemImageName: iconName)
 
+        let shortcut = UIApplicationShortcutItem(type: Bundle.main.bundleIdentifier! + ".toggleSpeakBG",
+                                                 localizedTitle: "Speak BG",
+                                                 localizedSubtitle: nil,
+                                                 icon: iconTemplate,
+                                                 userInfo: nil)
+        UIApplication.shared.shortcutItems = [shortcut]
+    }
+
+
+    // Handle the UIApplicationShortcutItem when the user taps on the Home Screen Quick Action. This function toggles the "Speak BG" setting in UserDefaultsRepository, speaks the current state (on/off) using AVSpeechSynthesizer, and updates the Quick Action appearance.
+    func handleShortcutItem(_ shortcutItem: UIApplicationShortcutItem) {
+        if let bundleIdentifier = Bundle.main.bundleIdentifier {
+            let expectedType = bundleIdentifier + ".toggleSpeakBG"
+            if shortcutItem.type == expectedType {
+                UserDefaultsRepository.speakBG.value.toggle()
+                let message = UserDefaultsRepository.speakBG.value ? "BG Speak is now on" : "BG Speak is now off"
+                let utterance = AVSpeechUtterance(string: message)
+                synthesizer.speak(utterance)
+                updateQuickActions()
+            }
+        }
+    }
+
+    // The following method is called when the user taps on the Home Screen Quick Action
+    func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+        handleShortcutItem(shortcutItem)
+    }
+
+    @objc func handleToggleSpeakBGEvent() {
+        updateQuickActions()
+    }
 }
 


### PR DESCRIPTION
Now you can easily toggle the "Speak BG" feature on and off directly from your home screen! I've added a Home Screen Quick Action that lets you control the feature with just a 3D touch on the LoopFollow app icon.

- Home Screen Quick Action: Quickly toggle "Speak BG" without going through the settings screens.
- Synced Settings: The switch in General Settings and the Quick Action are in sync.
- Audible Confirmation: Get instant feedback when you toggle the feature using the Quick Action.


![9D8E2754-EFF0-4BC9-AEAB-22B31E7B1434_1_201_a](https://user-images.githubusercontent.com/12718238/230408249-158f3f61-137a-4beb-adb9-ce0556f232ae.jpeg)
