### PR TITLE
Stores the time of the last speech announcement to prevent repeated a…

### DIFF
--- a/LoopFollow/Controllers/Alarms.swift
+++ b/LoopFollow/Controllers/Alarms.swift
@@ -847,8 +847,23 @@ extension MainViewController {
         
     }
     
-    
+    // Speaks the current blood glucose value and the change from the previous value.
+    // Repeated calls to the function within 30 seconds are prevented.
     func speakBG(currentValue: Int, previousValue: Int) {
+        // Get the current time
+        let currentTime = Date()
+
+        // Check if speakBG was called less than 30 seconds ago. If so, prevent repeated announcements and return.
+        // If `lastSpeechTime` is `nil` (i.e., this is the first time `speakBG` is being called), use `Date.distantPast` as the default
+        // value to ensure that the `guard` statement passes and the announcement is made.
+        guard currentTime.timeIntervalSince(lastSpeechTime ?? .distantPast) >= 30 else {
+            print("Repeated calls to speakBG detected!")
+            return
+        }
+
+        // Update the last speech time
+        self.lastSpeechTime = currentTime
+
         let bloodGlucoseDifference = currentValue - previousValue
         let negligibleThreshold = 3
         let differenceText: String

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -141,6 +141,10 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
     
     var snoozeTabItem: UITabBarItem = UITabBarItem()
     
+    // Stores the time of the last speech announcement to prevent repeated announcements.
+    // This is a temporary safeguard until the issue with multiple calls to speakBG is fixed.
+    var lastSpeechTime: Date?
+
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
This pull request adds a safeguard to prevent repeated announcements in the speakBG function. The safeguard checks if speakBG was called less than 30 seconds ago, and if so, it prevents the announcement and prints a message indicating that repeated calls were detected.

This safeguard was added in response to rare occurrences of double or triple announcements. While the root cause of these repeated announcements is not yet clear, this safeguard would prevent them from occurring. I not yet managed to reproduce this behavior using Xcode, but it is possible that it is related to timers, even if there should only be one timer that exists at any given time.