### PR TITLE
Add Nightscout URL and token validation to Settings

### DIFF
--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3F1335F351590E573D8E6962 /* Pods_LoopFollow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7D55B42A22051DAD69E89D0 /* Pods_LoopFollow.framework */; };
+		DD07B5C929E2F9C400C6A635 /* NightscoutUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD07B5C829E2F9C400C6A635 /* NightscoutUtils.swift */; };
 		DD152D3B24C01B2300361FA2 /* InfoDisplaySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD152D3A24C01B2300361FA2 /* InfoDisplaySettingsViewController.swift */; };
 		DD98F54424BCEFEE0007425A /* ShareClientExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */; };
 		DDCF979424C0D380002C9752 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCF979324C0D380002C9752 /* UIViewExtension.swift */; };
@@ -174,6 +175,7 @@
 /* Begin PBXFileReference section */
 		059B0FA59AABFE72FE13DDDA /* Pods-LoopFollow.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LoopFollow.release.xcconfig"; path = "Target Support Files/Pods-LoopFollow/Pods-LoopFollow.release.xcconfig"; sourceTree = "<group>"; };
 		A7D55B42A22051DAD69E89D0 /* Pods_LoopFollow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LoopFollow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD07B5C829E2F9C400C6A635 /* NightscoutUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutUtils.swift; sourceTree = "<group>"; };
 		DD152D3A24C01B2300361FA2 /* InfoDisplaySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoDisplaySettingsViewController.swift; sourceTree = "<group>"; };
 		DD98F54324BCEFEE0007425A /* ShareClientExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareClientExtension.swift; sourceTree = "<group>"; };
 		DDCF979324C0D380002C9752 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
@@ -603,6 +605,7 @@
 				FC1BDD2E24A232A3001B652C /* DataStructs.swift */,
 				FCD2A27C24C9D044009F7B7B /* Globals.swift */,
 				FC8589BE252B54F500C8FC73 /* Mobileprovision.swift */,
+				DD07B5C829E2F9C400C6A635 /* NightscoutUtils.swift */,
 			);
 			path = helpers;
 			sourceTree = "<group>";
@@ -866,6 +869,7 @@
 				FC3AE7B5249E8E0E00AAE1E0 /* LoopFollow.xcdatamodeld in Sources */,
 				FCC6886F2489A53800A0279D /* AppConstants.swift in Sources */,
 				FC16A97A24996673003D6245 /* NightScout.swift in Sources */,
+				DD07B5C929E2F9C400C6A635 /* NightscoutUtils.swift in Sources */,
 				FCC6886924898FB100A0279D /* UserDefaultsValueGroups.swift in Sources */,
 				FC16A97D24996747003D6245 /* Alarms.swift in Sources */,
 				FC16A97B249966A3003D6245 /* AlarmSound.swift in Sources */,

--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -1766,37 +1766,4 @@ extension MainViewController {
         }
         
     }
-    
-    static func createURLRequest(url: String, token: String?, path: String) -> URLRequest? {
-        var requestURLString = "\(url)\(path)"
-        
-        if let token = token {
-            let encodedToken = token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token
-            requestURLString += "?token=\(encodedToken)"
-        }
-        
-        guard let requestURL = URL(string: requestURLString) else {
-            return nil
-        }
-        
-        var request = URLRequest(url: requestURL)
-        request.httpMethod = "GET"
-        return request
-    }
-    
-    static func verifyURLAndToken(urlUser: String, token: String?, completion: @escaping (Bool) -> Void) {
-        guard let request = createURLRequest(url: urlUser, token: token, path: "/api/v1/status") else {
-            completion(false)
-            return
-        }
-        
-        let task = URLSession.shared.dataTask(with: request) { (_, response, error) in
-            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
-                completion(true)
-            } else {
-                completion(false)
-            }
-        }
-        task.resume()
-    }
 }

--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -1766,4 +1766,37 @@ extension MainViewController {
         }
         
     }
+    
+    static func createURLRequest(url: String, token: String?, path: String) -> URLRequest? {
+        var requestURLString = "\(url)\(path)"
+        
+        if let token = token {
+            let encodedToken = token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token
+            requestURLString += "?token=\(encodedToken)"
+        }
+        
+        guard let requestURL = URL(string: requestURLString) else {
+            return nil
+        }
+        
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        return request
+    }
+    
+    static func verifyURLAndToken(urlUser: String, token: String?, completion: @escaping (Bool) -> Void) {
+        guard let request = createURLRequest(url: urlUser, token: token, path: "/api/v1/status") else {
+            completion(false)
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: request) { (_, response, error) in
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+                completion(true)
+            } else {
+                completion(false)
+            }
+        }
+        task.resume()
+    }
 }

--- a/LoopFollow/helpers/NightscoutUtils.swift
+++ b/LoopFollow/helpers/NightscoutUtils.swift
@@ -1,0 +1,74 @@
+//
+//  NightscoutUtils.swift
+//  LoopFollow
+//
+//  Created by Jonas Björkert on 2023-04-09.
+//  Copyright © 2023 Jon Fawcett. All rights reserved.
+//
+
+import Foundation
+
+class NightscoutUtils {
+    enum NightscoutError {
+        case emptyAddress
+        case invalidURL
+        case networkError
+        case siteNotFound
+        case invalidToken
+        case tokenRequired
+        case unknown
+    }
+    
+    static func createURLRequest(url: String, token: String?, path: String) -> URLRequest? {
+        var requestURLString = "\(url)\(path)"
+        
+        if let token = token {
+            let encodedToken = token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? token
+            requestURLString += "?token=\(encodedToken)"
+        }
+        
+        guard let requestURL = URL(string: requestURLString) else {
+            return nil
+        }
+        
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        return request
+    }
+    
+    static func verifyURLAndToken(urlUser: String, token: String?, completion: @escaping (NightscoutError?) -> Void) {
+        if urlUser.isEmpty {
+            completion(.emptyAddress)
+            return
+        }
+
+        guard let request = createURLRequest(url: urlUser, token: token, path: "/api/v1/status") else {
+            completion(.invalidURL)
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let httpResponse = response as? HTTPURLResponse {
+                switch httpResponse.statusCode {
+                case 200:
+                    completion(nil)
+                case 401:
+                    if token == nil || token!.isEmpty {
+                        completion(.tokenRequired)
+                    } else {
+                        completion(.invalidToken) // Change this from "unauthorized"
+                    }
+                default:
+                    completion(.unknown)
+                }
+            }  else {
+                if let _ = error {
+                    completion(.siteNotFound)
+                } else {
+                    completion(.networkError)
+                }
+            }
+        }
+        task.resume()
+    }
+}


### PR DESCRIPTION
This pull request adds URL and token validation for Nightscout settings to improve user experience and provide clear error messages when the user enters incorrect or unreachable URLs and tokens. 

The changes include:
* Implementing a verifyURLAndToken function in a new NightscoutUtils class to check the validity of the user-entered URL and token by making a request to the Nightscout server.
* Adding various error cases to handle empty addresses, invalid URLs, network errors, site not found errors, invalid tokens, token requirements, and unknown errors.
* Updating the SettingsViewController to call the verifyURLAndToken function when the user enters or changes the URL or token, and updating the status label with appropriate error messages or an "OK" status when the URL and token are valid.
* Automatically checking the Nightscout status when the settings view is loaded and displaying the relevant status message.

These changes enhance the user experience by providing clear feedback on the validity of the Nightscout URL and token entered in the settings, helping users troubleshoot issues more effectively.

![image](https://user-images.githubusercontent.com/12718238/230787029-8d65b50e-b9ec-460a-8aff-e12849307053.png)
