### PR TITLE
Set default scheme to LoopFollow in workspace settings

### DIFF
--- a/LoopFollow.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/LoopFollow.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>SelectedSchemeName</key>
+    <string>LoopFollow</string>
+</dict>
+</plist>

--- a/LoopFollow.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/LoopFollow.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>SelectedSchemeName</key>
-    <string>LoopFollow</string>
-</dict>
-</plist>

--- a/LoopFollow.xcworkspace/xcshareddata/xcschemes/LoopFollow.xcscheme
+++ b/LoopFollow.xcworkspace/xcshareddata/xcschemes/LoopFollow.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FC9788132485969B00A7906C"
+               BuildableName = "Loop Follow.app"
+               BlueprintName = "LoopFollow"
+               ReferencedContainer = "container:LoopFollow.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FC9788132485969B00A7906C"
+            BuildableName = "Loop Follow.app"
+            BlueprintName = "LoopFollow"
+            ReferencedContainer = "container:LoopFollow.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FC9788132485969B00A7906C"
+            BuildableName = "Loop Follow.app"
+            BlueprintName = "LoopFollow"
+            ReferencedContainer = "container:LoopFollow.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This pull request updates the WorkspaceSettings.xcsettings file within the LoopFollow.xcworkspace to set the default scheme to LoopFollow. This change will make it more convenient for new users by automatically selecting the LoopFollow scheme when opening the project for the first time. As a result, this will also help avoid build errors and reduce the number of queries in forums related to scheme selection.

Note:
This setting only affects the default scheme selection when opening the workspace for the first time. Once a user selects a different scheme, Xcode will remember their preference for future sessions.