### PR TITLE
Low Battery Alarm

### DIFF
--- a/LoopFollow/Controllers/Alarms.swift
+++ b/LoopFollow/Controllers/Alarms.swift
@@ -496,9 +496,19 @@ extension MainViewController {
             }
         }
         
-        
-        
-        
+        if UserDefaultsRepository.alertBatteryActive.value {
+            let currentBatteryLevel = UserDefaultsRepository.deviceBatteryLevel.value
+            let alertAtBatteryLevel = Double(UserDefaultsRepository.alertBatteryLevel.value)
+            
+            if currentBatteryLevel <= alertAtBatteryLevel {
+                AlarmSound.whichAlarm = "Low Battery"
+
+                if UserDefaultsRepository.alertBatteryRepeat.value { numLoops = -1 }
+                triggerAlarm(sound: UserDefaultsRepository.alertBatterySound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: 1, snoozeIncrement: 1, audio: true)
+                return
+            }
+        }
+
         // still send persistent notification if no alarms trigger and persistent notification is on
         persistentNotification(bgTime: currentBGTime)
         
@@ -757,7 +767,12 @@ extension MainViewController {
 
         }
         
-        
+        if date > UserDefaultsRepository.alertBatterySnoozedTime.value ?? date {
+            UserDefaultsRepository.alertBatterySnoozedTime.setNil(key: "alertBatterySnoozedTime")
+            UserDefaultsRepository.alertBatteryIsSnoozed.value = false
+            alarms.reloadSnoozeTime(key: "alertBatterySnoozedTime", setNil: true)
+            alarms.reloadIsSnoozed(key: "alertBatteryIsSnoozed", value: false)
+        }
       }
     
     func checkQuietHours() {

--- a/LoopFollow/Controllers/Alarms.swift
+++ b/LoopFollow/Controllers/Alarms.swift
@@ -496,7 +496,7 @@ extension MainViewController {
             }
         }
         
-        if UserDefaultsRepository.alertBatteryActive.value {
+        if UserDefaultsRepository.alertBatteryActive.value && !UserDefaultsRepository.alertBatteryIsSnoozed.value {
             let currentBatteryLevel = UserDefaultsRepository.deviceBatteryLevel.value
             let alertAtBatteryLevel = Double(UserDefaultsRepository.alertBatteryLevel.value)
             

--- a/LoopFollow/Controllers/Alarms.swift
+++ b/LoopFollow/Controllers/Alarms.swift
@@ -504,7 +504,7 @@ extension MainViewController {
                 AlarmSound.whichAlarm = "Low Battery"
 
                 if UserDefaultsRepository.alertBatteryRepeat.value { numLoops = -1 }
-                triggerAlarm(sound: UserDefaultsRepository.alertBatterySound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: 1, snoozeIncrement: 1, audio: true)
+                triggerAlarm(sound: UserDefaultsRepository.alertBatterySound.value, snooozedBGReadingTime: nil, overrideVolume: UserDefaultsRepository.overrideSystemOutputVolume.value, numLoops: numLoops, snoozeTime: UserDefaultsRepository.alertBatterySnoozeHours.value, snoozeIncrement: 1, audio: true)
                 return
             }
         }

--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -514,6 +514,7 @@ extension MainViewController {
                 if let uploader = lastDeviceStatus?["uploader"] as? [String:AnyObject] {
                     let upbat = uploader["battery"] as! Double
                     tableData[4].value = String(format:"%.0f", upbat) + "%"
+                    UserDefaultsRepository.deviceBatteryLevel.value = upbat
                 }
             }
         }

--- a/LoopFollow/ViewControllers/AlarmViewController.swift
+++ b/LoopFollow/ViewControllers/AlarmViewController.swift
@@ -3205,6 +3205,20 @@ class AlarmViewController: FormViewController {
             guard let value = row.value else { return }
             UserDefaultsRepository.alertBatteryLevel.value = Int(value)
         }
+        <<< StepperRow("alertBatterySnoozeHours") { row in
+            row.title = "Snooze Hours"
+            row.cell.stepper.stepValue = 1
+            row.cell.stepper.minimumValue = 1
+            row.cell.stepper.maximumValue = 24
+            row.value = Double(UserDefaultsRepository.alertBatterySnoozeHours.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return "\(Int(value))"
+            }
+        }.onChange { [weak self] row in
+            guard let value = row.value else { return }
+            UserDefaultsRepository.alertBatterySnoozeHours.value = Int(value)
+        }
         <<< PickerInputRow<String>("alertBatterySound") { row in
             row.title = "Sound"
             row.options = soundFiles

--- a/LoopFollow/ViewControllers/AlarmViewController.swift
+++ b/LoopFollow/ViewControllers/AlarmViewController.swift
@@ -339,7 +339,7 @@ class AlarmViewController: FormViewController {
         
         <<< SegmentedRow<String>("otherAlerts3"){ row in
                 row.title = ""
-                row.options = ["IOB", "COB"]
+                row.options = ["IOB", "COB", "Battery"]
                 if UserDefaultsRepository.url.value == "" {
                     row.hidden = true
                 }
@@ -389,6 +389,7 @@ class AlarmViewController: FormViewController {
         
         buildIOB()
         buildCOB()
+        buildBatteryAlarm()
         
         buildSnoozeAll()
         buildAlarmSettings()
@@ -3178,6 +3179,56 @@ class AlarmViewController: FormViewController {
         }
     }
 
+    func buildBatteryAlarm(){
+        form
+        +++ Section(header: "Battery Alarm", footer: "Activates a notification alert whenever the battery level drops below a user-defined threshold, allowing for proactive device charging and power management.") { row in
+            row.hidden = "$otherAlerts3 != 'Battery'"
+        }
+        <<< SwitchRow("alertBatteryActive"){ row in
+            row.title = "Active"
+            row.value = UserDefaultsRepository.alertBatteryActive.value
+        }.onChange { [weak self] row in
+            guard let value = row.value else { return }
+            UserDefaultsRepository.alertBatteryActive.value = value
+        }
+        <<< StepperRow("alertBatteryLevel") { row in
+            row.title = "Battery Level"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 0
+            row.cell.stepper.maximumValue = 100
+            row.value = Double(UserDefaultsRepository.alertBatteryLevel.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return "\(Int(value))%"
+            }
+        }.onChange { [weak self] row in
+            guard let value = row.value else { return }
+            UserDefaultsRepository.alertBatteryLevel.value = Int(value)
+        }
+        <<< PickerInputRow<String>("alertBatterySound") { row in
+            row.title = "Sound"
+            row.options = soundFiles
+            row.value = UserDefaultsRepository.alertBatterySound.value
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return "\(String(value.replacingOccurrences(of: "_", with: " ")))"
+            }
+        }.onChange { [weak self] row in
+            guard let value = row.value else { return }
+            UserDefaultsRepository.alertBatterySound.value = value
+            AlarmSound.setSoundFile(str: value)
+            AlarmSound.stop()
+            AlarmSound.playTest()
+        }
+        <<< SwitchRow("alertBatteryRepeat"){ row in
+            row.title = "Repeat Sound"
+            row.value = UserDefaultsRepository.alertBatteryRepeat.value
+        }.onChange { [weak self] row in
+            guard let value = row.value else { return }
+            UserDefaultsRepository.alertBatteryRepeat.value = value
+        }
+    }
+    
     func buildAlarmSettings() {
            form
             +++ Section(header: "Alarm Settings", footer: "")

--- a/LoopFollow/ViewControllers/SnoozeViewController.swift
+++ b/LoopFollow/ViewControllers/SnoozeViewController.swift
@@ -215,12 +215,13 @@ class SnoozeViewController: UIViewController, UNUserNotificationCenterDelegate {
         guard let alarms = self.tabBarController!.viewControllers?[1] as? AlarmViewController else { return }
         alarms.reloadIsSnoozed(key: "alertCOBIsSnoozed", value: true)
         alarms.reloadSnoozeTime(key: "alertCOBSnoozedTime", setNil: false, value: Date().addingTimeInterval(TimeInterval(snoozeForMinuteStepper.value * 60 * 60)))
-       } else if AlarmSound.whichAlarm == "Battery Alarm" {
+       } else if AlarmSound.whichAlarm == "Low Battery" {
            UserDefaultsRepository.alertBatteryIsSnoozed.value = true
-           UserDefaultsRepository.alertBatterySnoozedTime.value = Date().addingTimeInterval(TimeInterval(snoozeForMinuteStepper.value * 60))
+
+           UserDefaultsRepository.alertBatterySnoozedTime.value = Date().addingTimeInterval(TimeInterval(snoozeForMinuteStepper.value * 60 * 60))
            guard let alarms = self.tabBarController!.viewControllers?[1] as? AlarmViewController else { return }
            alarms.reloadIsSnoozed(key: "alertBatteryIsSnoozed", value: true)
-           alarms.reloadSnoozeTime(key: "alertBatterySnoozedTime", setNil: false, value: Date().addingTimeInterval(TimeInterval(snoozeForMinuteStepper.value * 60)))
+           alarms.reloadSnoozeTime(key: "alertBatterySnoozedTime", setNil: false, value: Date().addingTimeInterval(TimeInterval(snoozeForMinuteStepper.value * 60 * 60)))
        }
     }
     

--- a/LoopFollow/ViewControllers/SnoozeViewController.swift
+++ b/LoopFollow/ViewControllers/SnoozeViewController.swift
@@ -215,6 +215,12 @@ class SnoozeViewController: UIViewController, UNUserNotificationCenterDelegate {
         guard let alarms = self.tabBarController!.viewControllers?[1] as? AlarmViewController else { return }
         alarms.reloadIsSnoozed(key: "alertCOBIsSnoozed", value: true)
         alarms.reloadSnoozeTime(key: "alertCOBSnoozedTime", setNil: false, value: Date().addingTimeInterval(TimeInterval(snoozeForMinuteStepper.value * 60 * 60)))
+       } else if AlarmSound.whichAlarm == "Battery Alarm" {
+           UserDefaultsRepository.alertBatteryIsSnoozed.value = true
+           UserDefaultsRepository.alertBatterySnoozedTime.value = Date().addingTimeInterval(TimeInterval(snoozeForMinuteStepper.value * 60))
+           guard let alarms = self.tabBarController!.viewControllers?[1] as? AlarmViewController else { return }
+           alarms.reloadIsSnoozed(key: "alertBatteryIsSnoozed", value: true)
+           alarms.reloadSnoozeTime(key: "alertBatterySnoozedTime", setNil: false, value: Date().addingTimeInterval(TimeInterval(snoozeForMinuteStepper.value * 60)))
        }
     }
     

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -16,7 +16,7 @@ import Foundation
 import UIKit
 
 class UserDefaultsRepository {
-
+    
     // DisplayValues total
     static let infoDataTotal = UserDefaultsValue<Int>(key: "infoDataTotal", default: 0)
     static let infoNames = UserDefaultsValue<[String]>(key: "infoNames", default: [
@@ -84,7 +84,7 @@ class UserDefaultsRepository {
         default: UIApplication.shared.isIdleTimerDisabled,
         onChange: { screenlock in
             UIApplication.shared.isIdleTimerDisabled = screenlock
-    })
+        })
     
     // Advanced Settings
     //static let onlyDownloadBG = UserDefaultsValue<Bool>(key: "onlyDownloadBG", default: false)
@@ -98,7 +98,7 @@ class UserDefaultsRepository {
     static let alwaysDownloadAllBG = UserDefaultsValue<Bool>(key: "alwaysDownloadAllBG", default: true)
     static let bgUpdateDelay = UserDefaultsValue<Int>(key: "bgUpdateDelay", default: 10)
     static let downloadDays = UserDefaultsValue<Int>(key: "downloadDays", default: 1)
-
+    
     
     // Watch Calendar Settings
     static let calendarIdentifier = UserDefaultsValue<String>(key: "calendarIdentifier", default: "")
@@ -429,4 +429,13 @@ class UserDefaultsRepository {
     static let alertCOBAutosnooze = UserDefaultsValue<String>(key: "alertCOBAutosnooze", default: "Never")
     static let alertCOBAutosnoozeDay = UserDefaultsValue<Bool>(key: "alertCOBAutosnoozeDay", default: false)
     static let alertCOBAutosnoozeNight = UserDefaultsValue<Bool>(key: "alertCOBAutosnoozeNight", default: false)
+    
+    static let alertBatteryActive = UserDefaultsValue<Bool>(key: "alertBatteryActive", default: false)
+    static let alertBatteryLevel = UserDefaultsValue<Int>(key: "alertBatteryLevel", default: 20)
+    static let alertBatterySound = UserDefaultsValue<String>(key: "alertBatterySound", default: "Machine_Charge")
+    static let alertBatteryRepeat = UserDefaultsValue<Bool>(key: "alertBatteryRepeat", default: false)    
+    static let alertBatteryIsSnoozed = UserDefaultsValue<Bool>(key: "alertBatteryIsSnoozed", default: false)
+    static let alertBatterySnoozedTime = UserDefaultsValue<Date?>(key: "alertBatterySnoozedTime", default: nil)
+    static let alertBatterySnoozeHours = UserDefaultsValue<Int>(key: "alertBatterySnoozeHours", default: 1)
+    static var deviceBatteryLevel: UserDefaultsValue<Double> = UserDefaultsValue(key: "deviceBatteryLevel", default: 100.0)
 }

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -431,9 +431,9 @@ class UserDefaultsRepository {
     static let alertCOBAutosnoozeNight = UserDefaultsValue<Bool>(key: "alertCOBAutosnoozeNight", default: false)
     
     static let alertBatteryActive = UserDefaultsValue<Bool>(key: "alertBatteryActive", default: false)
-    static let alertBatteryLevel = UserDefaultsValue<Int>(key: "alertBatteryLevel", default: 20)
+    static let alertBatteryLevel = UserDefaultsValue<Int>(key: "alertBatteryLevel", default: 25)
     static let alertBatterySound = UserDefaultsValue<String>(key: "alertBatterySound", default: "Machine_Charge")
-    static let alertBatteryRepeat = UserDefaultsValue<Bool>(key: "alertBatteryRepeat", default: false)    
+    static let alertBatteryRepeat = UserDefaultsValue<Bool>(key: "alertBatteryRepeat", default: true)
     static let alertBatteryIsSnoozed = UserDefaultsValue<Bool>(key: "alertBatteryIsSnoozed", default: false)
     static let alertBatterySnoozedTime = UserDefaultsValue<Date?>(key: "alertBatterySnoozedTime", default: nil)
     static let alertBatterySnoozeHours = UserDefaultsValue<Int>(key: "alertBatterySnoozeHours", default: 1)


### PR DESCRIPTION
This pull request introduces a new low battery alarm feature to LoopFollow. The feature triggers an alarm when the Loop phone battery level falls below a user-specified threshold. This enhancement is aimed at ensuring that users can take timely action to recharge their device's battery, thereby maintaining uninterrupted functioning of Loop.

Changes include:
- A new setting that allows users to specify the battery level at which the alarm should be triggered.
- A mechanism to monitor the device's battery level and trigger an alarm when the level falls below the specified threshold.
- A Snooze functionality for the battery alarm, along with customizable snooze duration.

Looking forward to your feedback on this new feature.

