### PR TITLE
 Improve JSON Decoding in NightScout.swift and ShareClientExtension.swift

### DIFF
--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -193,8 +193,25 @@ extension MainViewController {
                 
             }
             
+            var entriesResponse: [ShareGlucoseData]?
             let decoder = JSONDecoder()
-            let entriesResponse = try? decoder.decode([ShareGlucoseData].self, from: data)
+            do {
+                entriesResponse = try decoder.decode([ShareGlucoseData].self, from: data)
+            } catch let DecodingError.dataCorrupted(context) {
+                print("Data corrupted: \(context)")
+            } catch let DecodingError.keyNotFound(key, context) {
+                print("Key '\(key)' not found: \(context.debugDescription)")
+                print("codingPath: \(context.codingPath)")
+            } catch let DecodingError.valueNotFound(value, context) {
+                print("Value '\(value)' not found: \(context.debugDescription)")
+                print("codingPath: \(context.codingPath)")
+            } catch let DecodingError.typeMismatch(type, context)  {
+                print("Type '\(type)' mismatch: \(context.debugDescription)")
+                print("codingPath: \(context.codingPath)")
+            } catch {
+                print("Error decoding JSON: \(error)")
+            }
+
             if var nsData = entriesResponse {
                 DispatchQueue.main.async {
                     // transform NS data to look like Dex data

--- a/LoopFollow/Extensions/ShareClientExtension.swift
+++ b/LoopFollow/Extensions/ShareClientExtension.swift
@@ -10,9 +10,37 @@ import Foundation
 import ShareClient
 
 public struct ShareGlucoseData: Codable {
-   var sgv: Int
-   var date: TimeInterval
-   var direction: String?
+    var sgv: Int
+    var date: TimeInterval
+    var direction: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sgv
+        case date
+        case direction
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let sgvAsDouble = try? container.decode(Double.self, forKey: .sgv) {
+            sgv = Int(sgvAsDouble.rounded())
+        } else if let sgvAsInt = try? container.decode(Int.self, forKey: .sgv) {
+            sgv = sgvAsInt
+        } else {
+            throw DecodingError.dataCorruptedError(forKey: .sgv, in: container, debugDescription: "Expected to decode an Integer or Double.")
+        }
+
+        // Decode the other properties
+        date = try container.decode(TimeInterval.self, forKey: .date)
+        direction = try container.decodeIfPresent(String.self, forKey: .direction)
+    }
+
+    public init(sgv: Int, date: TimeInterval, direction: String?) {
+        self.sgv = sgv
+        self.date = date
+        self.direction = direction
+    }
 }
 
 private var TrendTable: [String] = [


### PR DESCRIPTION
Summary
This pull request includes enhancements to the sgv JSON decoding process to provide more robust error handling and flexibility in how we treat incoming data.

Changes in NightScout.swift
I have wrapped the JSON decoding operation in a do-catch block to better handle any potential decoding errors. Now, rather than merely attempting to decode and potentially failing silently, the application will now provide specific feedback about the nature of any encountered decoding error. This includes data corruption, missing keys, missing values, and type mismatches. This should aid in diagnosing problems with incoming JSON data.

Changes in ShareClientExtension.swift
I've also refined the ShareGlucoseData structure to better handle variations in incoming data.

The sgv property now accepts both Double and Int types, with Double values being rounded to the nearest integer. This helps accommodate different formats that may be encountered in incoming JSON payloads. For example, with Dexcom G7, there seems to start to appear decimal sgv values for some users.